### PR TITLE
Check HTTP status code before parsing dashboard response in GetDashboard

### DIFF
--- a/signoz/internal/client/dashboard.go
+++ b/signoz/internal/client/dashboard.go
@@ -39,15 +39,15 @@ func (c *Client) GetDashboard(ctx context.Context, dashboardUUID string) (*dashb
 		return nil, err
 	}
 
-	if bodyObj.Status != "success" || bodyObj.Error != "" {
-		tflog.Error(ctx, "GetDashboard: error while fetching dashboard", map[string]any{
-			"error":     bodyObj.Error,
-			"errorType": bodyObj.ErrorType,
-			"data":      bodyObj.Data,
-		})
+if resp.StatusCode != http.StatusOK {
+	tflog.Error(ctx, "GetDashboard: error while fetching dashboard", map[string]any{
+		"statusCode": resp.StatusCode,
+		"status":     resp.Status,
+	})
 
-		return &dashboardData{}, fmt.Errorf("error while fetching dashboard: %s", bodyObj.Error)
-	}
+	return &dashboardData{}, fmt.Errorf("error while fetching dashboard: received status code %d", resp.StatusCode)
+}
+
 
 	tflog.Debug(ctx, "GetDashboard: dashboard fetched", map[string]any{"dashboard": bodyObj.Data})
 

--- a/signoz/internal/client/dashboard.go
+++ b/signoz/internal/client/dashboard.go
@@ -39,15 +39,14 @@ func (c *Client) GetDashboard(ctx context.Context, dashboardUUID string) (*dashb
 		return nil, err
 	}
 
-if resp.StatusCode != http.StatusOK {
-	tflog.Error(ctx, "GetDashboard: error while fetching dashboard", map[string]any{
-		"statusCode": resp.StatusCode,
-		"status":     resp.Status,
-	})
+	if resp.StatusCode != http.StatusOK {
+		tflog.Error(ctx, "GetDashboard: error while fetching dashboard", map[string]any{
+			"statusCode": resp.StatusCode,
+			"status":     resp.Status,
+		})
 
-	return &dashboardData{}, fmt.Errorf("error while fetching dashboard: received status code %d", resp.StatusCode)
-}
-
+		return &dashboardData{}, fmt.Errorf("error while fetching dashboard: received status code %d", resp.StatusCode)
+	}
 
 	tflog.Debug(ctx, "GetDashboard: dashboard fetched", map[string]any{"dashboard": bodyObj.Data})
 


### PR DESCRIPTION
#### Features

-  None

#### Fixes 
- #40 

#### Chores

-  None

#### Refactors

- Updated error handling logic in GetDashboard to use HTTP status codes for validation.
-  Check for HTTP status code instead of relying on bodyObj.Status or bodyObj.Error when fetching dashboard data.
- Attached image contains updated Code. Before is right side and After is left side. 

<img width="1808" height="964" alt="image" src="https://github.com/user-attachments/assets/09f22b71-5eb7-4e60-a783-2cf2dd6aa6aa" />


#### Tests

- Added no test
