### PR TITLE
fix(alert-labels): no need for alert labels from api

### DIFF
--- a/signoz/internal/provider/resource/alert.go
+++ b/signoz/internal/provider/resource/alert.go
@@ -282,6 +282,11 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 	plan.UpdateAt = types.StringValue(alert.UpdateAt)
 	plan.UpdateBy = types.StringValue(alert.UpdateBy)
 
+	// Set labels from API response
+	var diag diag.Diagnostics
+	plan.Labels, diag = alert.LabelsToTerraform()
+	resp.Diagnostics.Append(diag...)
+
 	// Set state to populated data.
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
We need to give labels section as optional as labels are not compulsory, it should be user defined.