### PR TITLE
fix(905): fix conditon extra fields

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -37,7 +37,9 @@ resource "signoz_alert" "new_alert" {
       compositeQuery = {
         builderQueries = {
           A = {
-            ShiftBy = 0
+            IsAnomaly            = false
+            QueriesUsedInFormula = null
+            ShiftBy              = 0
             aggregateAttribute = {
               dataType = "float64"
               isColumn = true
@@ -200,10 +202,6 @@ resource "signoz_alert" "new_alert_v2" {
 
   labels = {
     "team" = "platform"
-  }
-
-  lifecycle {
-    ignore_changes = [condition]
   }
 }
 

--- a/examples/resources/signoz_alert/resource.tf
+++ b/examples/resources/signoz_alert/resource.tf
@@ -22,9 +22,9 @@ resource "signoz_alert" "new_alert" {
       compositeQuery = {
         builderQueries = {
           A = {
-            IsAnomaly= false
+            IsAnomaly            = false
             QueriesUsedInFormula = null
-            ShiftBy = 0
+            ShiftBy              = 0
             aggregateAttribute = {
               dataType = "float64"
               isColumn = true

--- a/examples/resources/signoz_alert/resource.tf
+++ b/examples/resources/signoz_alert/resource.tf
@@ -22,6 +22,8 @@ resource "signoz_alert" "new_alert" {
       compositeQuery = {
         builderQueries = {
           A = {
+            IsAnomaly= false
+            QueriesUsedInFormula = null
             ShiftBy = 0
             aggregateAttribute = {
               dataType = "float64"
@@ -185,10 +187,6 @@ resource "signoz_alert" "new_alert_v2" {
 
   labels = {
     "team" = "platform"
-  }
-
-  lifecycle {
-    ignore_changes = [condition]
   }
 }
 

--- a/signoz/internal/provider/resource/alert.go
+++ b/signoz/internal/provider/resource/alert.go
@@ -365,6 +365,13 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 	plan.UpdateAt = types.StringValue(alert.UpdateAt)
 	plan.UpdateBy = types.StringValue(alert.UpdateBy)
 
+	//As condition is JSON string, updated response contains extra keys
+	plan.Condition, err = alertPayload.ConditionToTerraform()
+	if err != nil {
+		addErr(&resp.Diagnostics, err, operationCreate, SigNozAlert)
+		return
+	}
+
 	var diagLabels diag.Diagnostics
 	plan.Labels, diagLabels = alert.LabelsToTerraform()
 	resp.Diagnostics.Append(diagLabels...)
@@ -568,7 +575,8 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	plan.UpdateAt = types.StringValue(alert.UpdateAt)
 	plan.UpdateBy = types.StringValue(alert.UpdateBy)
 
-	plan.Condition, err = alert.ConditionToTerraform()
+	//As condition is JSON string, updated response contains extra keys
+	plan.Condition, err = alertUpdate.ConditionToTerraform()
 	if err != nil {
 		addErr(&resp.Diagnostics, err, operationUpdate, SigNozAlert)
 		return


### PR DESCRIPTION
#### Fixes

- Currently Condition structure is not defined we are using it as json encode string, while creating and updating alerts, it send extra fields which are not present in the terraform state leading to errors while updating condition, so for this currently we are not checking the condition state from response, instead we check it from the payload itself.

