### PR TITLE
fix(dashboard): ensure panelMap and variables default to empty JSON object

### DIFF
--- a/signoz/internal/model/dashboard.go
+++ b/signoz/internal/model/dashboard.go
@@ -47,6 +47,9 @@ func (d Dashboard) VariablesToTerraform() (types.String, error) {
 	if err != nil {
 		return types.StringValue(""), err
 	}
+	if variables == "" {
+		variables = "{}"
+	}
 
 	return types.StringValue(variables), nil
 }

--- a/signoz/internal/model/dashboard.go
+++ b/signoz/internal/model/dashboard.go
@@ -17,7 +17,7 @@ type Dashboard struct {
 	Description             string                   `json:"description"`
 	Layout                  []map[string]interface{} `json:"layout"`
 	Name                    string                   `json:"name"`
-	PanelMap                map[string]interface{}   `json:"panelMap,omitempty"`
+	PanelMap                map[string]interface{}   `json:"panelMap"`
 	Source                  string                   `json:"source"`
 	Tags                    []string                 `json:"tags"`
 	Title                   string                   `json:"title"`
@@ -34,6 +34,9 @@ func (d Dashboard) PanelMapToTerraform() (types.String, error) {
 	panelMap, err := structure.FlattenJsonToString(d.PanelMap)
 	if err != nil {
 		return types.StringNull(), err
+	}
+	if panelMap == "" {
+		panelMap = "{}"
 	}
 
 	return types.StringValue(panelMap), nil


### PR DESCRIPTION
Fixes

  - Ensure panelMap and variables default to empty JSON object {} instead of empty string, preventing perpetual Terraform plan
  diffs on dashboards
  
  
  fixes #44 