### PR TITLE
fix(dashboard): idempotent variables and optional attribute

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -253,13 +253,13 @@ output "dashboard_new" {
 - `name` (String) Name of the dashboard.
 - `title` (String) Title of the dashboard.
 - `uploaded_grafana` (Boolean)
-- `variables` (String) Variables for the dashboard.
 - `version` (String) Version of the dashboard.
 - `widgets` (String) Widgets for the dashboard.
 
 ### Optional
 
 - `panel_map` (String)
+- `variables` (String) JSON map of dashboard template variables. Omit or use {} when none.
 - `source` (String) Source of the dashboard. By default, it is <SIGNOZ_ENDPOINT>/dashboard.
 - `tags` (List of String) Tags of the dashboard.
 

--- a/signoz/internal/model/dashboard.go
+++ b/signoz/internal/model/dashboard.go
@@ -40,6 +40,12 @@ func (d Dashboard) PanelMapToTerraform() (types.String, error) {
 }
 
 func (d Dashboard) VariablesToTerraform() (types.String, error) {
+	// Handle empty variables map: return "{}" instead of ""
+	// to maintain idempotency across apply cycles
+	if d.Variables == nil || len(d.Variables) == 0 {
+		return types.StringValue("{}"), nil
+	}
+
 	variables, err := structure.FlattenJsonToString(d.Variables)
 	if err != nil {
 		return types.StringValue(""), err

--- a/signoz/internal/model/dashboard.go
+++ b/signoz/internal/model/dashboard.go
@@ -79,7 +79,16 @@ func (d Dashboard) WidgetsToTerraform() (types.String, error) {
 }
 
 func (d *Dashboard) SetVariables(tfVariables types.String) error {
-	variables, err := structure.ExpandJsonFromString(tfVariables.ValueString())
+	if tfVariables.IsNull() || tfVariables.IsUnknown() {
+		d.Variables = map[string]interface{}{}
+		return nil
+	}
+	s := tfVariables.ValueString()
+	if s == "" {
+		d.Variables = map[string]interface{}{}
+		return nil
+	}
+	variables, err := structure.ExpandJsonFromString(s)
 	if err != nil {
 		return err
 	}

--- a/signoz/internal/provider/resource/dashboard.go
+++ b/signoz/internal/provider/resource/dashboard.go
@@ -120,8 +120,8 @@ func (r *dashboardResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Required: true,
 			},
 			attr.Variables: schema.StringAttribute{
-				Required:    true,
-				Description: "Variables for the dashboard.",
+				Optional:    true,
+				Description: "JSON map of dashboard template variables. Omit or use {} when none.",
 			},
 			attr.Widgets: schema.StringAttribute{
 				Required:    true,
@@ -220,6 +220,11 @@ func (r *dashboardResource) Create(ctx context.Context, req resource.CreateReque
 	plan.UpdatedAt = types.StringValue(dashboard.UpdatedAt)
 	plan.UpdatedBy = types.StringValue(dashboard.UpdatedBy)
 	plan.Version = types.StringValue(dashboard.Data.Version)
+
+	// align optional variables with read path (empty api map -> "{}")
+	if plan.Variables.IsNull() || plan.Variables.ValueString() == "" {
+		plan.Variables = types.StringValue("{}")
+	}
 
 	// Set state to populated data.
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)


### PR DESCRIPTION
## Problem

1. **Read drift:** When `variables` was set to `"{}"`, `VariablesToTerraform()` used `structure.FlattenJsonToString()` on an empty map, which produced `""`. The next read disagreed with state (`"{}"` vs `""`), so plans showed perpetual drift.

2. **Required noise:** `variables` was required even when dashboards have no template variables, so every resource had to pass `variables = "{}"` or equivalent.

## Root cause

- Empty `map[string]interface{}` serialized to an empty string instead of stable JSON `"{}"`.
- Schema marked `variables` as required.

## Solution

- **`VariablesToTerraform()`:** If `variables` is nil or empty, return `types.StringValue("{}")` so read/update match state and the API’s empty object.

- **Schema:** `variables` is **optional**. Omit it when there are no dashboard variables.

- **`SetVariables()`:** Treat null, unknown, and empty string as `{}` for the API (same idea as `SetPanelMap` for empty panel map).

- **Create:** If `variables` was omitted or empty, set state to `"{}"` after create so it matches the read path immediately.

- **Docs:** `docs/resources/dashboard.md` schema section updated (variables under Optional).

## Testing

- Apply with `variables = "{}"` or omit `variables`; second `terraform plan` should show no spurious `variables` change.
- Omit `variables` entirely on a new `signoz_dashboard`; create succeeds and later plans stay clean.

## Example (no variables)

```hcl
resource "signoz_dashboard" "example" {
  # ... other required attributes ...
  # variables omitted — provider sends {} to SigNoz
}
```

## Example (explicit empty)

```hcl
variables = jsonencode({})
# or
variables = "{}"
```

Both remain valid and stay aligned with read after apply.
