### PR TITLE
fix(client): treat empty / non-JSON 2xx update response as success

### DIFF
--- a/signoz/internal/client/alert.go
+++ b/signoz/internal/client/alert.go
@@ -118,13 +118,8 @@ func (c *Client) UpdateAlert(ctx context.Context, alertID string, alertPayload *
 		return err
 	}
 
-	var bodyObj signozResponse
-	err = json.Unmarshal(body, &bodyObj)
-	if err != nil {
-		return err
-	}
-
-	if bodyObj.Status != "success" || bodyObj.Error != "" {
+	bodyObj, parsed := parseStatusResponse(body)
+	if parsed && (bodyObj.Status != "success" || bodyObj.Error != "") {
 		tflog.Error(ctx, "UpdateAlert: error while updating alert", map[string]any{
 			"error":     bodyObj.Error,
 			"errorType": bodyObj.ErrorType,

--- a/signoz/internal/client/dashboard.go
+++ b/signoz/internal/client/dashboard.go
@@ -118,13 +118,8 @@ func (c *Client) UpdateDashboard(ctx context.Context, dashboardUUID string, dash
 		return err
 	}
 
-	var bodyObj signozResponse
-	err = json.Unmarshal(body, &bodyObj)
-	if err != nil {
-		return err
-	}
-
-	if bodyObj.Status != "success" || bodyObj.Error != "" {
+	bodyObj, parsed := parseStatusResponse(body)
+	if parsed && (bodyObj.Status != "success" || bodyObj.Error != "") {
 		tflog.Error(ctx, "UpdateDashboard: error while updating dashboard", map[string]any{
 			"error":     bodyObj.Error,
 			"errorType": bodyObj.ErrorType,

--- a/signoz/internal/client/types.go
+++ b/signoz/internal/client/types.go
@@ -1,6 +1,10 @@
 package client
 
-import "github.com/SigNoz/terraform-provider-signoz/signoz/internal/model"
+import (
+	"encoding/json"
+
+	"github.com/SigNoz/terraform-provider-signoz/signoz/internal/model"
+)
 
 // signozResponse - Maps the response data.
 type signozResponse struct {
@@ -8,6 +12,22 @@ type signozResponse struct {
 	Data      interface{} `json:"data"`
 	ErrorType string      `json:"errorType"`
 	Error     string      `json:"error"`
+}
+
+// parseStatusResponse decodes the SigNoz status envelope from a 2xx body.
+// Returns parsed=true with the envelope (caller still checks Status/Error);
+// parsed=false when the body is empty or not JSON, in which case treat as
+// success — doRequest already filtered non-2xx, and some endpoints (notably
+// PUT /api/v1/dashboards/{uuid}) return plain-text status rather than the
+// envelope. See https://github.com/SigNoz/terraform-provider-signoz/issues/71.
+func parseStatusResponse(body []byte) (response signozResponse, parsed bool) {
+	if len(body) == 0 {
+		return signozResponse{}, false
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return signozResponse{}, false
+	}
+	return response, true
 }
 
 // alertResponse - Maps the response data of GetAlert and CreateAlert.


### PR DESCRIPTION
Fixes #71.

`terraform apply` on a `signoz_dashboard` update fails with `unexpected
end of JSON input` even though the dashboard is updated server-side.

## Cause

`Client.doRequest` filters non-2xx responses to errors, then each update
function runs `json.Unmarshal(body, &signozResponse)`. When the body is
empty or non-JSON, the unmarshal error is returned and shadows the
otherwise-successful HTTP call.

`PUT /api/v1/dashboards/{uuid}` returns a plain-text status (`dashboard
updated`) rather than the `{"status":"success",...}` envelope the client
expects — so `UpdateAlert` works today but `UpdateDashboard` doesn't.

## Fix

New `parseStatusResponse(body)` helper:

- `parsed=true` with the decoded envelope when the body is JSON — caller
  still checks `Status` / `Error` to surface application-level failures.
- `parsed=false` when the body is empty or not JSON — treat as success
  (the HTTP status was already 2xx, that was the only meaningful signal).

Applied to `UpdateDashboard` and `UpdateAlert`. `Get`/`Create` need the
JSON payload; `Delete` already discards it — unchanged.

## Test plan

- [x] Reproduced against SigNoz Cloud `us2`: same payload succeeds via
  direct PUT and fails via the provider before this change; succeeds
  after.
- [ ] CI: existing `go build` + `golangci-lint` workflow.

No `*_test.go` files exist in the repo today; happy to follow up with a
table-tested unit for `parseStatusResponse` in a separate PR if you'd
like one.
