### PR TITLE
fix(service_account): regenerate client for 204 No Content delete

### DIFF
--- a/internal/apiclients/zz_generated_client.go
+++ b/internal/apiclients/zz_generated_client.go
@@ -1257,7 +1257,6 @@ func (r CreateServiceAccountResponse) ContentType() string {
 type DeleteServiceAccountResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON204      *string
 	JSON401      *apitypes.RenderErrorResponse
 	JSON403      *apitypes.RenderErrorResponse
 	JSON404      *apitypes.RenderErrorResponse
@@ -1328,7 +1327,6 @@ func (r GetServiceAccountResponse) ContentType() string {
 type UpdateServiceAccountResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON204      *string
 	JSON400      *apitypes.RenderErrorResponse
 	JSON401      *apitypes.RenderErrorResponse
 	JSON403      *apitypes.RenderErrorResponse
@@ -2034,13 +2032,6 @@ func ParseDeleteServiceAccountResponse(rsp *http.Response) (*DeleteServiceAccoun
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 204:
-		var dest string
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON204 = &dest
-
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest apitypes.RenderErrorResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -2145,13 +2136,6 @@ func ParseUpdateServiceAccountResponse(rsp *http.Response) (*UpdateServiceAccoun
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 204:
-		var dest string
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON204 = &dest
-
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest apitypes.RenderErrorResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/internal/apitypes/zz_generated_errors_json.go
+++ b/internal/apitypes/zz_generated_errors_json.go
@@ -5,12 +5,11 @@ package apitypes
 
 // ErrorsJSON defines model for ErrorsJSON.
 type ErrorsJSON struct {
-	Code              string                           `json:"code"`
-	Errors            *[]ErrorsResponseerroradditional `json:"errors,omitempty"`
-	InvalidReferences *[]string                        `json:"invalidReferences,omitempty"`
-	Message           string                           `json:"message"`
-	Retry             *ErrorsResponseretryjson         `json:"retry,omitempty"`
-	Suggestions       *[]string                        `json:"suggestions,omitempty"`
-	Type              *string                          `json:"type,omitempty"`
-	Url               *string                          `json:"url,omitempty"`
+	Code        string                           `json:"code"`
+	Errors      *[]ErrorsResponseerroradditional `json:"errors,omitempty"`
+	Message     string                           `json:"message"`
+	Retry       *ErrorsResponseretryjson         `json:"retry,omitempty"`
+	Suggestions *[]string                        `json:"suggestions,omitempty"`
+	Type        *string                          `json:"type,omitempty"`
+	Url         *string                          `json:"url,omitempty"`
 }

--- a/internal/apitypes/zz_generated_errors_responseerroradditional.go
+++ b/internal/apitypes/zz_generated_errors_responseerroradditional.go
@@ -5,5 +5,6 @@ package apitypes
 
 // ErrorsResponseerroradditional defines model for ErrorsResponseerroradditional.
 type ErrorsResponseerroradditional struct {
-	Message *string `json:"message,omitempty"`
+	Message     *string   `json:"message,omitempty"`
+	Suggestions *[]string `json:"suggestions,omitempty"`
 }


### PR DESCRIPTION
## Summary

Regenerate the provider (skaff pipeline) against the SigNoz OpenAPI spec now that the service account DELETE correctly declares `204 No Content` with **no body** (spec fix in SigNoz/signoz#11720 / #11719).

## Fix

Previously the generated `ParseDeleteServiceAccountResponse` had an unconditional `json.Unmarshal` for the 204 (because the spec declared an `application/json` string body). The server returns 204 with an empty body, so the provider failed:

```
Error: Delete service_account
unexpected end of JSON input
```

With the spec corrected, the regenerated client drops the 204 unmarshal case - the delete now succeeds.