### PR TITLE
fix(alert): rule ID churn + Update error label + out-of-band deletion handling

### DIFF
--- a/signoz/internal/provider/resource/alert.go
+++ b/signoz/internal/provider/resource/alert.go
@@ -307,12 +307,15 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 			Summary:     plan.Summary.ValueString(),
 		},
 		BroadcastToAll: plan.BroadcastToAll.ValueBool(),
-		EvalWindow:     plan.EvalWindow.ValueString(),
-		Frequency:      plan.Frequency.ValueString(),
-		RuleType:       plan.RuleType.ValueString(),
-		Source:         plan.Source.ValueString(),
-		Version:        plan.Version.ValueString(),
-		SchemaVersion:  plan.SchemaVersion.ValueString(),
+		// Update sends Disabled in its payload; Create must too.
+		// Otherwise a `disabled = true` alert is created enabled, and the response (disabled=false) is inconsistent with the plan — which taints the resource and forces a destroy+recreate.
+		Disabled:      plan.Disabled.ValueBool(),
+		EvalWindow:    plan.EvalWindow.ValueString(),
+		Frequency:     plan.Frequency.ValueString(),
+		RuleType:      plan.RuleType.ValueString(),
+		Source:        plan.Source.ValueString(),
+		Version:       plan.Version.ValueString(),
+		SchemaVersion: plan.SchemaVersion.ValueString(),
 	}
 
 	err := alertPayload.SetCondition(plan.Condition)
@@ -358,6 +361,9 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 	plan.ID = types.StringValue(alert.ID)
 	plan.BroadcastToAll = types.BoolValue(alert.BroadcastToAll)
 	plan.Disabled = types.BoolValue(alert.Disabled)
+	// rule_type is Optional+Computed with no default, so it plans as "known after apply" when omitted from config.
+	// Like preferred_channels, Create must read it back from the response or it stays unknown after apply and churns the resource.
+	plan.RuleType = types.StringValue(alert.RuleType)
 	plan.Source = types.StringValue(alert.Source)
 	plan.State = types.StringValue(alert.State)
 	plan.SchemaVersion = types.StringValue(alert.SchemaVersion)
@@ -376,6 +382,13 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 	var diagLabels diag.Diagnostics
 	plan.Labels, diagLabels = alert.LabelsToTerraform()
 	resp.Diagnostics.Append(diagLabels...)
+
+	// preferred_channels is Optional+Computed, so it plans as "known after apply" when omitted from config.
+	// Create must populate it from the response, as Read and Update already do.
+	// Leaving it unknown makes Terraform reject the apply, taint the resource, and destroy+recreate it — churning the rule ID on every apply.
+	var diagPreferredChannels diag.Diagnostics
+	plan.PreferredChannels, diagPreferredChannels = alert.PreferredChannelsToTerraform()
+	resp.Diagnostics.Append(diagPreferredChannels...)
 
 	if alert.SchemaVersion != "" && alert.SchemaVersion != "v1" {
 		plan.NotificationSettings, diagLabels = alert.NotificationSettingsToTerraform(ctx)

--- a/signoz/internal/provider/resource/alert.go
+++ b/signoz/internal/provider/resource/alert.go
@@ -538,7 +538,7 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if !utils.IsNullOrUnknown(plan.NotificationSettings) {
 		err := alertUpdate.SetNotificationSettings(ctx, plan.NotificationSettings)
 		if err != nil {
-			addErr(&resp.Diagnostics, err, operationCreate, SigNozAlert)
+			addErr(&resp.Diagnostics, err, operationUpdate, SigNozAlert)
 			return
 		}
 	}
@@ -546,7 +546,7 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if !plan.Evaluation.IsNull() && plan.Evaluation.ValueString() != "" {
 		err := alertUpdate.SetEvaluation(plan.Evaluation)
 		if err != nil {
-			addErr(&resp.Diagnostics, err, operationCreate, SigNozAlert)
+			addErr(&resp.Diagnostics, err, operationUpdate, SigNozAlert)
 			return
 		}
 	}

--- a/signoz/internal/provider/resource/alert.go
+++ b/signoz/internal/provider/resource/alert.go
@@ -2,7 +2,9 @@ package resource
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
 
 	"github.com/SigNoz/terraform-provider-signoz/internal/apiclients"
@@ -426,6 +428,13 @@ func (r *alertResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	// Get refreshed alert from SigNoz.
 	alert, err := r.client.GetAlert(ctx, state.ID.ValueString())
 	if err != nil {
+		// If the alert was deleted out of band, drop it from state so Terraform plans a recreate
+		// instead of erroring on every subsequent plan/apply (and so destroy can proceed).
+		var apiErr *apiclients.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		addErr(&resp.Diagnostics, err, operationRead, SigNozAlert)
 		return
 	}
@@ -642,6 +651,11 @@ func (r *alertResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	// Delete existing alert.
 	err := r.client.DeleteAlert(ctx, state.ID.ValueString())
 	if err != nil {
+		// An already-deleted alert (404) is not an error — delete is idempotent.
+		var apiErr *apiclients.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return
+		}
 		addErr(&resp.Diagnostics, err, operationDelete, SigNozAlert)
 		return
 	}

--- a/tests/fixtures/terraform.py
+++ b/tests/fixtures/terraform.py
@@ -6,6 +6,7 @@ declares a `dev_overrides` block. dev_overrides bypass the registry and the
 local build.
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -124,3 +125,30 @@ class Terraform:
         result = self._run("destroy", "-auto-approve")
         assert result.returncode == 0, f"destroy failed:\n{result.stdout}\n{result.stderr}"
         return result
+
+    def state_resource(self, resource_type: str) -> dict:
+        """Return the attribute values of the first resource of the given type in the current state."""
+        result = self._run("show", "-json")
+        assert result.returncode == 0, f"show failed:\n{result.stdout}\n{result.stderr}"
+        state = json.loads(result.stdout)
+        for res in state.get("values", {}).get("root_module", {}).get("resources", []):
+            if res.get("type") == resource_type:
+                return res["values"]
+        raise AssertionError(f"no {resource_type} resource found in state")
+
+    def state_resource_id(self, resource_type: str) -> str:
+        return self.state_resource(resource_type)["id"]
+
+    def _run_raw(self, *args: str) -> subprocess.CompletedProcess:
+        """Like _run but without appending -no-color, for commands where flag position matters."""
+        result = subprocess.run([self.binary, *args], cwd=self.workdir, env=self.env, text=True, capture_output=True)
+        logger.info("terraform %s -> %d", " ".join(args), result.returncode)
+        return result
+
+    def state_rm(self, address: str) -> None:
+        result = self._run_raw("state", "rm", "-no-color", address)
+        assert result.returncode == 0, f"state rm failed:\n{result.stdout}\n{result.stderr}"
+
+    def import_resource(self, address: str, resource_id: str) -> None:
+        result = self._run_raw("import", "-no-color", "-input=false", address, resource_id)
+        assert result.returncode == 0, f"import failed:\n{result.stdout}\n{result.stderr}"

--- a/tests/fixtures/terraform.py
+++ b/tests/fixtures/terraform.py
@@ -115,6 +115,11 @@ class Terraform:
         assert result.returncode == 0, f"apply failed:\n{result.stdout}\n{result.stderr}"
         return result
 
+    def apply_expecting_failure(self) -> subprocess.CompletedProcess:
+        result = self._run("apply", "-auto-approve")
+        assert result.returncode != 0, f"expected apply to fail but it succeeded:\n{result.stdout}"
+        return result
+
     def plan_exit_code(self) -> int:
         # -detailed-exitcode: 0 = no changes, 1 = error, 2 = changes (drift).
         result = self._run("plan", "-detailed-exitcode")

--- a/tests/integration/tests/test_alert_rule_id_stability.py
+++ b/tests/integration/tests/test_alert_rule_id_stability.py
@@ -1,0 +1,225 @@
+"""Regression test: creating an alert must not churn its rule ID.
+
+The pre-fix provider left `preferred_channels` unknown after Create and ignored `disabled` in the
+create payload. Terraform therefore rejected the create result and tainted the freshly created
+alert, so the next apply destroyed and recreated it — assigning a brand new rule ID every time.
+That is what drove the "rule IDs keep changing" problem for downstream IaC (broken doc links,
+lost alert history). See resource/alert.go Create().
+
+This exercises the fix end to end: create succeeds, and a benign update is applied in place with
+the rule ID preserved rather than destroy+recreate.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from fixtures.signoz import SigNoz
+from fixtures.terraform import EXAMPLES, VERSIONS_TF, Terraform
+
+# A disabled traces alert that leaves the Optional+Computed attributes with no default
+# (preferred_channels AND rule_type) unset — the exact shape that tripped the bug: both plan as
+# "known after apply" and Create must repopulate them. `disabled = true` also exercises the
+# create-payload Disabled fix (and matches how our alerts are shipped: created disabled, enabled later).
+ALERT_TF = """\
+resource "signoz_alert" "churn" {
+  alert          = "rule-id stability regression"
+  alert_type     = "TRACES_BASED_ALERT"
+  description    = "__DESC__"
+  summary        = "rule-id stability regression"
+  severity       = "warning"
+  version        = "v5"
+  schema_version = "v2alpha1"
+  disabled       = true
+
+  condition = jsonencode({
+    compositeQuery = {
+      queryType = "builder"
+      panelType = "graph"
+      unit      = "ns"
+      queries = [{
+        type = "builder_query"
+        spec = {
+          name         = "A"
+          signal       = "traces"
+          stepInterval = 60
+          aggregations = [{ expression = "p99(duration_nano)" }]
+          filter       = { expression = "service.name = 'demo'" }
+        }
+      }]
+    }
+    selectedQueryName = "A"
+    thresholds = {
+      kind = "basic"
+      spec = [{
+        name       = "warning"
+        op         = "above"
+        matchType  = "at_least_once"
+        target     = 10
+        targetUnit = "s"
+        channels   = ["slack"]
+      }]
+    }
+  })
+
+  evaluation = jsonencode({
+    kind = "rolling"
+    spec = { evalWindow = "5m", frequency = "1m" }
+  })
+
+  notification_settings = {
+    group_by = ["service.name"]
+    renotify = {
+      enabled      = true
+      interval     = "30m"
+      alert_states = ["firing"]
+    }
+  }
+
+  labels = {
+    team = "regression"
+  }
+}
+"""
+
+
+def test_alert_rule_id_stable_across_update(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "before"))
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+
+    # Create. Pre-fix this fails: preferred_channels is unknown after apply, so Terraform taints the
+    # resource ("invalid result object after apply").
+    terraform.apply()
+    rule_id = terraform.state_resource_id("signoz_alert")
+    assert rule_id, "alert was not created"
+
+    try:
+        # A benign change. Pre-fix, the tainted resource is destroyed and recreated with a new id.
+        (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "after"))
+        terraform.apply()
+
+        assert terraform.state_resource_id("signoz_alert") == rule_id, (
+            "rule ID churned across an update (destroy+recreate instead of in-place)"
+        )
+    finally:
+        terraform.destroy()
+
+
+def test_alert_enable_disable_toggle(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """Enabling a disabled alert (disabled true -> false) must be in place, not a recreate.
+
+    This is the "ship the alert disabled, enable it later" workflow. Pre-fix, Create ignored disabled
+    in the payload, so the alert never actually landed disabled and the enable path was unreliable.
+    """
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "toggle"))  # disabled = true
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+
+    terraform.apply()
+    created = terraform.state_resource("signoz_alert")
+    assert created["disabled"] is True, "alert was not created disabled"
+    rule_id = created["id"]
+
+    try:
+        (workdir / "alert.tf").write_text(
+            ALERT_TF.replace("__DESC__", "toggle").replace("disabled       = true", "disabled       = false")
+        )
+        terraform.apply()
+
+        after = terraform.state_resource("signoz_alert")
+        assert after["disabled"] is False, "enabling the alert did not take effect"
+        assert after["id"] == rule_id, "enabling the alert churned the rule ID"
+    finally:
+        terraform.destroy()
+
+
+def test_alert_import_roundtrip(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """After importing an existing alert by id, reconciling must be in place — not a destroy+recreate."""
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "import"))
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+
+    terraform.apply()
+    rule_id = terraform.state_resource_id("signoz_alert")
+
+    try:
+        terraform.state_rm("signoz_alert.churn")
+        terraform.import_resource("signoz_alert.churn", rule_id)
+        # Applying against the imported state must reconcile in place, preserving the id.
+        terraform.apply()
+        assert terraform.state_resource_id("signoz_alert") == rule_id, (
+            "import round-trip replaced the resource (new rule ID)"
+        )
+    finally:
+        terraform.destroy()
+
+
+# The churn (unknown-value-after-apply) affected every alert type, not just traces. Assert each shipped
+# example creates without the "invalid result object after apply" error. Channel names are rewritten to a
+# channel that exists in the test env (examples reference environment-specific channels).
+_ALERT_EXAMPLES = sorted((EXAMPLES / "resources" / "signoz_alert").glob("*.tf"))
+_CREATE_SKIP = {"resource_anomaly.tf": 'API rejects rule_type "anomaly_rule" (unrelated to this fix)'}
+
+
+@pytest.mark.parametrize(
+    "example",
+    [
+        pytest.param(
+            p,
+            id=p.name,
+            marks=([pytest.mark.skip(reason=_CREATE_SKIP[p.name])] if p.name in _CREATE_SKIP else []),
+        )
+        for p in _ALERT_EXAMPLES
+    ],
+)
+def test_alert_example_creates_without_unknown_values(
+    example: Path,
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    src = re.sub(r"channels(\s*)=(\s*)\[[^\]]*\]", r'channels\1=\2["slack"]', example.read_text())
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / example.name).write_text(src)
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+
+    # Pre-fix this errors with "invalid result object after apply" (unknown preferred_channels/rule_type).
+    terraform.apply()
+    try:
+        assert terraform.state_resource_id("signoz_alert")
+    finally:
+        terraform.destroy()

--- a/tests/integration/tests/test_alert_rule_id_stability.py
+++ b/tests/integration/tests/test_alert_rule_id_stability.py
@@ -14,6 +14,7 @@ import re
 from pathlib import Path
 
 import pytest
+import requests
 
 from fixtures.signoz import SigNoz
 from fixtures.terraform import EXAMPLES, VERSIONS_TF, Terraform
@@ -265,5 +266,125 @@ def test_alert_update_error_reports_update_operation(
         output = result.stdout + result.stderr
         assert "failed to update" in output, f"update failure not labeled 'update':\n{output}"
         assert "failed to create" not in output, f"update failure mislabeled as 'create':\n{output}"
+    finally:
+        terraform.destroy()
+
+
+def _delete_alert_out_of_band(signoz: SigNoz, rule_id: str) -> None:
+    resp = requests.delete(
+        f"{signoz.endpoint}/api/v1/rules/{rule_id}",
+        headers={"SIGNOZ-API-KEY": signoz.access_token},
+        timeout=10,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_alert_read_recreates_after_out_of_band_delete(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """If the alert is deleted outside Terraform, a refresh must plan a recreate — not hard-error.
+
+    Read previously turned any GetAlert failure into an error, so a 404 wedged every future plan/apply.
+    """
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "oob-read"))
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+    terraform.apply()
+    rule_id = terraform.state_resource_id("signoz_alert")
+
+    try:
+        _delete_alert_out_of_band(signoz, rule_id)
+        # Refreshing must not error; it should detect the deletion and plan a recreate (exit code 2).
+        assert terraform.plan_exit_code() == 2, "expected a recreate plan after out-of-band deletion"
+        terraform.apply()
+        new_id = terraform.state_resource_id("signoz_alert")
+        assert new_id and new_id != rule_id, "alert was not recreated after out-of-band deletion"
+    finally:
+        terraform.destroy()
+
+
+def test_alert_destroy_tolerates_out_of_band_delete(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """`terraform destroy` must succeed even if the alert was already deleted out of band."""
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "oob-destroy"))
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+    terraform.apply()
+    rule_id = terraform.state_resource_id("signoz_alert")
+
+    _delete_alert_out_of_band(signoz, rule_id)
+    # Pre-fix, destroy's refresh hit a 404 and hard-errored, leaving the resource stuck in state.
+    terraform.destroy()
+
+
+def test_alert_preferred_channels_set_round_trips(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """Setting preferred_channels explicitly must round-trip and stay stable across an update."""
+    cfg = ALERT_TF.replace("__DESC__", "pc").replace(
+        "  disabled       = true", '  disabled       = true\n  preferred_channels = ["slack"]'
+    )
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(cfg)
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+    terraform.apply()
+    created = terraform.state_resource("signoz_alert")
+    assert created["preferred_channels"] == ["slack"], created["preferred_channels"]
+    rule_id = created["id"]
+
+    try:
+        (workdir / "alert.tf").write_text(cfg.replace('description    = "pc"', 'description    = "pc2"'))
+        terraform.apply()
+        assert terraform.state_resource_id("signoz_alert") == rule_id
+    finally:
+        terraform.destroy()
+
+
+def test_alert_condition_update_in_place(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """Changing the condition must update in place and preserve the rule ID."""
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "cond"))
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+    terraform.apply()
+    rule_id = terraform.state_resource_id("signoz_alert")
+
+    try:
+        # Change the threshold target inside the condition JSON.
+        changed = ALERT_TF.replace("__DESC__", "cond").replace("target     = 10", "target     = 12")
+        assert "target     = 12" in changed, "condition target anchor drifted from ALERT_TF"
+        (workdir / "alert.tf").write_text(changed)
+        terraform.apply()
+        assert terraform.state_resource_id("signoz_alert") == rule_id, "condition change churned the rule ID"
     finally:
         terraform.destroy()

--- a/tests/integration/tests/test_alert_rule_id_stability.py
+++ b/tests/integration/tests/test_alert_rule_id_stability.py
@@ -223,3 +223,47 @@ def test_alert_example_creates_without_unknown_values(
         assert terraform.state_resource_id("signoz_alert")
     finally:
         terraform.destroy()
+
+
+# The evaluation block from ALERT_TF, and a malformed replacement that makes SetEvaluation fail during
+# Update (evaluation is a plain string attribute with no schema validation, so it reaches the provider).
+_VALID_EVALUATION = """  evaluation = jsonencode({
+    kind = "rolling"
+    spec = { evalWindow = "5m", frequency = "1m" }
+  })"""
+_BROKEN_EVALUATION = '  evaluation = "{ not valid json"'
+
+
+def test_alert_update_error_reports_update_operation(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """A failure during Update must be reported as an "update" error, not "create".
+
+    Two Update error paths (SetNotificationSettings / SetEvaluation) passed operationCreate to addErr,
+    so an update-time failure surfaced as "failed to create signoz_alert". This drives a real update
+    failure (malformed evaluation JSON) and asserts the diagnostic is labeled with the update operation.
+    """
+    assert _VALID_EVALUATION in ALERT_TF, "evaluation anchor drifted from ALERT_TF"
+
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "err"))
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+    terraform.apply()
+
+    try:
+        broken = ALERT_TF.replace("__DESC__", "err").replace(_VALID_EVALUATION, _BROKEN_EVALUATION)
+        (workdir / "alert.tf").write_text(broken)
+
+        result = terraform.apply_expecting_failure()
+        output = result.stdout + result.stderr
+        assert "failed to update" in output, f"update failure not labeled 'update':\n{output}"
+        assert "failed to create" not in output, f"update failure mislabeled as 'create':\n{output}"
+    finally:
+        terraform.destroy()


### PR DESCRIPTION
Three correctness fixes to the `signoz_alert` resource, with a comprehensive integration test suite. Fixes #117.

## Fixes

**1. Rule ID churn — the resource was destroyed + recreated on every `terraform apply`** (new `ruleId` each time, breaking ID-based references and resetting alert history). `Create()` left three things inconsistent/unknown after apply, so Terraform tainted the freshly created resource and recreated it on the next apply. `Read()`/`Update()` already handled all three — only `Create()` was missing them:
- `preferred_channels` (Optional+Computed) was never populated from the response → *"unknown value after apply."*
- `rule_type` (Optional+Computed, no default) was never populated from the response → same, when omitted from config.
- `Disabled` was never sent in the create payload → a `disabled = true` alert came back `disabled = false` → *"inconsistent result after apply."*

Fix: mirror `Update()` in `Create()`.

**2. Update errors were mislabeled as create errors.** Two `Update()` paths (`notification_settings`/`evaluation` failures) passed `operationCreate` to `addErr`, so an update-time failure surfaced as *"failed to create signoz_alert."* Now `operationUpdate`.

**3. Out-of-band deletion wedged the resource.** `Read()` turned any `GetAlert` failure into an error, so an alert deleted outside Terraform (HTTP 404) made every subsequent `plan`/`apply` hard-fail — and even blocked `destroy` (which refreshes first). `Read()` now removes the resource from state on 404 (so Terraform plans a recreate), and `Delete()` treats 404 as success (idempotent).

## Testing

Verified against a real SigNoz (local `foundryctl` Docker instance, provider built from source, Terraform `dev_overrides`). Every test below was confirmed to **fail on the pre-fix provider and pass after** (or is added coverage for a behavior the fixes must not regress):

- `test_alert_rule_id_stable_across_update` — omits `preferred_channels`+`rule_type`, `disabled=true`; ruleId survives an update.
- `test_alert_enable_disable_toggle` — `disabled` `true→false` applies in place, ruleId preserved.
- `test_alert_import_roundtrip` — `import` reconciles in place, not destroy+recreate.
- `test_alert_example_creates_without_unknown_values` — parametrized across shipped examples (metric/PROMQL/logs/tiered/traces).
- `test_alert_update_error_reports_update_operation` — a real update failure is labeled `update`, not `create`.
- `test_alert_read_recreates_after_out_of_band_delete` — 404 on refresh plans a recreate, doesn't error.
- `test_alert_destroy_tolerates_out_of_band_delete` — destroy succeeds when the alert is already gone.
- `test_alert_preferred_channels_set_round_trips` — explicit `preferred_channels` round-trips.
- `test_alert_condition_update_in_place` — a condition change updates in place, ruleId preserved.

`go build` / `go vet` / `ruff` all clean; suite is **13 passed, 1 skipped** (`anomaly`, see below).

## Known limitations (found while testing; out of scope for this PR)

These are pre-existing and separable from the churn fix; I can open dedicated issues/PRs:
- **`condition`/`evaluation` server-enrichment drift** — the server stores `condition` with extra keys the config never sent (e.g. `compositeQuery…spec.source = ""`, `thresholds.spec[].recoveryTarget = null`), so a no-op plan shows a benign in-place update (ruleId preserved). `evaluation` is additionally read back from the response (unlike `condition`, which is read from the payload), so it can hit the same inconsistency. This is why the full-CRUD example tests remain skipped.
- **`severity` inside the `labels` map** — `LabelsToTerraform` strips `severity`, so a config that puts `severity` in `labels` errors with *"element severity has vanished."* (This is the only remaining blocker for `resource_anomaly.tf`, alongside…)
- **`anomaly_rule`** — rejected by the `rule_type` validator; allowing it also needs the labels fix above.
- **`disabled` has `json:",omitempty"`** — re-enable happens to work because the API PUT is full-replace, but it's fragile.
