### PR TITLE
fix(alert): report Update errors with operationUpdate label

### DIFF
--- a/signoz/internal/provider/resource/alert.go
+++ b/signoz/internal/provider/resource/alert.go
@@ -525,7 +525,7 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if !utils.IsNullOrUnknown(plan.NotificationSettings) {
 		err := alertUpdate.SetNotificationSettings(ctx, plan.NotificationSettings)
 		if err != nil {
-			addErr(&resp.Diagnostics, err, operationCreate, SigNozAlert)
+			addErr(&resp.Diagnostics, err, operationUpdate, SigNozAlert)
 			return
 		}
 	}
@@ -533,7 +533,7 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if !plan.Evaluation.IsNull() && plan.Evaluation.ValueString() != "" {
 		err := alertUpdate.SetEvaluation(plan.Evaluation)
 		if err != nil {
-			addErr(&resp.Diagnostics, err, operationCreate, SigNozAlert)
+			addErr(&resp.Diagnostics, err, operationUpdate, SigNozAlert)
 			return
 		}
 	}


### PR DESCRIPTION
Two error paths in `Update()` for the `signoz_alert` resource pass `operationCreate` to `addErr`, so a failure while setting `notification_settings` or `evaluation` **during an update** is surfaced to the user as a *create* error. Use `operationUpdate`, matching the other error paths in the same function.

Cosmetic (error-message) fix — no behavior change.

---

Note: I initially intended to also add `anomaly_rule` to the `rule_type` allow-list here (the shipped `examples/resources/signoz_alert/resource_anomaly.tf` uses it, but the validator rejects it). On testing against a live SigNoz, allowing it is not sufficient — that example then fails with *"Provider produced inconsistent result after apply: .labels: element \"severity\" has vanished"* (`LabelsToTerraform` strips the `severity` key that the config's `labels` map contains). So anomaly support needs more than a one-line allow-list change and is better handled as its own PR alongside the labels round-trip fix.
