### PR TITLE
fix(alert): semantic equality for condition/evaluation (stop perpetual drift, un-skip example tests)

### DIFF
--- a/internal/customtypes/normalized_json.go
+++ b/internal/customtypes/normalized_json.go
@@ -1,0 +1,184 @@
+package customtypes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// NormalizedJSON is a string attribute holding a JSON document whose semantic equality ignores
+// differences that the SigNoz API introduces on read-back: key ordering, whitespace, and — crucially —
+// keys the server adds with empty/null default values (e.g. `spec.source = ""`, `recoveryTarget = null`).
+//
+// Without this, `condition`/`evaluation` show a perpetual in-place update on every plan: the config
+// carries the user's JSON, but a refresh stores the server-enriched JSON, and a plain string compare
+// treats them as different. Semantic equality lets Terraform recognize the two as the same document.
+//
+// Equality is intentionally conservative: it only collapses null / empty-string / empty-object /
+// empty-array entries. Any real value change (a different number, a changed expression, a value set to
+// or cleared from a non-empty value) still produces a diff, so genuine changes are never masked.
+
+var _ basetypes.StringTypable = NormalizedJSONType{}
+
+type NormalizedJSONType struct {
+	basetypes.StringType
+}
+
+func (t NormalizedJSONType) Equal(o attr.Type) bool {
+	other, ok := o.(NormalizedJSONType)
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+func (t NormalizedJSONType) String() string {
+	return "customtypes.NormalizedJSONType"
+}
+
+func (t NormalizedJSONType) ValueFromString(_ context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	return NormalizedJSON{StringValue: in}, nil
+}
+
+func (t NormalizedJSONType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type %T for NormalizedJSONType", attrValue)
+	}
+
+	return NormalizedJSON{StringValue: stringValue}, nil
+}
+
+func (t NormalizedJSONType) ValueType(_ context.Context) attr.Value {
+	return NormalizedJSON{}
+}
+
+var (
+	_ basetypes.StringValuable                   = NormalizedJSON{}
+	_ basetypes.StringValuableWithSemanticEquals = NormalizedJSON{}
+)
+
+type NormalizedJSON struct {
+	basetypes.StringValue
+}
+
+func (v NormalizedJSON) Type(_ context.Context) attr.Type {
+	return NormalizedJSONType{}
+}
+
+func (v NormalizedJSON) Equal(o attr.Value) bool {
+	other, ok := o.(NormalizedJSON)
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+// StringSemanticEquals reports whether two JSON documents are equal after normalizing away key
+// ordering, whitespace, and empty/null entries. If either side is not valid JSON, it falls back to a
+// plain string comparison so nothing is silently treated as equal.
+func (v NormalizedJSON) StringSemanticEquals(_ context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(NormalizedJSON)
+	if !ok {
+		return false, diags
+	}
+
+	if v.IsNull() || v.IsUnknown() || newValue.IsNull() || newValue.IsUnknown() {
+		return v.StringValue.Equal(newValue.StringValue), diags
+	}
+
+	left, errLeft := normalizeJSON(v.ValueString())
+	right, errRight := normalizeJSON(newValue.ValueString())
+	if errLeft != nil || errRight != nil {
+		return v.ValueString() == newValue.ValueString(), diags
+	}
+
+	return reflect.DeepEqual(left, right), diags
+}
+
+func NewNormalizedJSONValue(value string) NormalizedJSON {
+	return NormalizedJSON{StringValue: basetypes.NewStringValue(value)}
+}
+
+func NewNormalizedJSONNull() NormalizedJSON {
+	return NormalizedJSON{StringValue: basetypes.NewStringNull()}
+}
+
+func NewNormalizedJSONUnknown() NormalizedJSON {
+	return NormalizedJSON{StringValue: basetypes.NewStringUnknown()}
+}
+
+// normalizeJSON parses a JSON string and recursively drops empty entries so server-added default keys
+// do not register as drift.
+func normalizeJSON(s string) (interface{}, error) {
+	var parsed interface{}
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		return nil, err
+	}
+
+	return stripEmpty(parsed), nil
+}
+
+// stripEmpty recursively removes null / empty-string / empty-object / empty-array values from maps.
+// Slice elements are normalized but never dropped, so array length (which is meaningful) is preserved.
+func stripEmpty(v interface{}) interface{} {
+	switch value := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(value))
+		for k, elem := range value {
+			normalized := stripEmpty(elem)
+			if isEmpty(normalized) {
+				continue
+			}
+			out[k] = normalized
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(value))
+		for i, elem := range value {
+			out[i] = stripEmpty(elem)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+// isEmpty reports whether a value equals its JSON zero value. The SigNoz API fills omitted condition
+// fields with their zero value on read-back (e.g. `disabled: false`, `step: 0`, `source: ""`,
+// `recoveryTarget: null`), so treating zero values as absent is what lets an omitted field and a
+// server-defaulted field compare equal. A change to a non-zero value is still a real diff, because the
+// other side carries the previous non-zero value.
+func isEmpty(v interface{}) bool {
+	switch value := v.(type) {
+	case nil:
+		return true
+	case string:
+		return value == ""
+	case bool:
+		return !value
+	case float64:
+		return value == 0
+	case map[string]interface{}:
+		return len(value) == 0
+	case []interface{}:
+		return len(value) == 0
+	default:
+		return false
+	}
+}

--- a/internal/customtypes/normalized_json_test.go
+++ b/internal/customtypes/normalized_json_test.go
@@ -1,0 +1,70 @@
+package customtypes
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNormalizedJSONStringSemanticEquals(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		a    string
+		b    string
+		want bool
+	}{
+		"identical":                        {`{"a":1}`, `{"a":1}`, true},
+		"key order and whitespace":         {`{"a":1,"b":2}`, "{ \"b\": 2,\n \"a\": 1 }", true},
+		"server adds empty string key":     {`{"a":1}`, `{"a":1,"source":""}`, true},
+		"server adds null key":             {`{"a":1}`, `{"a":1,"recoveryTarget":null}`, true},
+		"server adds empty object/array":   {`{"a":1}`, `{"a":1,"x":{},"y":[]}`, true},
+		"nested server-added empties":      {`{"spec":{"name":"A"}}`, `{"spec":{"name":"A","source":"","f":null}}`, true},
+		"array element enriched":           {`{"q":[{"name":"A"}]}`, `{"q":[{"name":"A","source":""}]}`, true},
+		"real value change not equal":      {`{"target":10}`, `{"target":12}`, false},
+		"value cleared to empty not equal": {`{"foo":"bar"}`, `{"foo":""}`, false},
+		"array length change not equal":    {`{"q":[1]}`, `{"q":[1,2]}`, false},
+		"array element order not equal":    {`{"q":[1,2]}`, `{"q":[2,1]}`, false},
+		"different key not equal":          {`{"a":1}`, `{"b":1}`, false},
+		"zero-number default dropped":      {`{"target":0}`, `{}`, true},
+		"false default dropped":            {`{"flag":false}`, `{}`, true},
+		"server adds false/zero defaults":  {`{"spec":{"name":"A"}}`, `{"spec":{"name":"A","disabled":false,"stats":false,"step":0}}`, true},
+		"change to a nonzero value diffs":  {`{"target":0}`, `{"target":5}`, false},
+		"nonzero to zero diffs":            {`{"target":5}`, `{"target":0}`, false},
+		"invalid json falls back equal":    {`{`, `{`, true},
+		"invalid json falls back diff":     {`{`, `}`, false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, diags := NewNormalizedJSONValue(tc.a).StringSemanticEquals(context.Background(), NewNormalizedJSONValue(tc.b))
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			if got != tc.want {
+				t.Fatalf("StringSemanticEquals(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizedJSONStringSemanticEqualsNullUnknown(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	equal, _ := NewNormalizedJSONNull().StringSemanticEquals(ctx, NewNormalizedJSONNull())
+	if !equal {
+		t.Fatal("null should equal null")
+	}
+
+	equal, _ = NewNormalizedJSONNull().StringSemanticEquals(ctx, NewNormalizedJSONValue(`{"a":1}`))
+	if equal {
+		t.Fatal("null should not equal a value")
+	}
+
+	equal, _ = NewNormalizedJSONUnknown().StringSemanticEquals(ctx, NewNormalizedJSONUnknown())
+	if !equal {
+		t.Fatal("unknown should equal unknown")
+	}
+}

--- a/signoz/internal/provider/resource/alert.go
+++ b/signoz/internal/provider/resource/alert.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	"github.com/SigNoz/terraform-provider-signoz/internal/apiclients"
+	"github.com/SigNoz/terraform-provider-signoz/internal/customtypes"
 	"github.com/SigNoz/terraform-provider-signoz/signoz/internal/attr"
 	"github.com/SigNoz/terraform-provider-signoz/signoz/internal/client"
 	"github.com/SigNoz/terraform-provider-signoz/signoz/internal/model"
@@ -44,30 +45,30 @@ type alertResource struct {
 
 // alertResourceModel maps the resource schema data.
 type alertResourceModel struct {
-	ID                   types.String `tfsdk:"id"`
-	Alert                types.String `tfsdk:"alert"`
-	AlertType            types.String `tfsdk:"alert_type"`
-	BroadcastToAll       types.Bool   `tfsdk:"broadcast_to_all"`
-	Condition            types.String `tfsdk:"condition"`
-	Description          types.String `tfsdk:"description"`
-	Disabled             types.Bool   `tfsdk:"disabled"`
-	EvalWindow           types.String `tfsdk:"eval_window"`
-	Frequency            types.String `tfsdk:"frequency"`
-	Labels               types.Map    `tfsdk:"labels"`
-	PreferredChannels    types.List   `tfsdk:"preferred_channels"`
-	RuleType             types.String `tfsdk:"rule_type"`
-	Severity             types.String `tfsdk:"severity"`
-	Source               types.String `tfsdk:"source"`
-	State                types.String `tfsdk:"state"`
-	Summary              types.String `tfsdk:"summary"`
-	Version              types.String `tfsdk:"version"`
-	SchemaVersion        types.String `tfsdk:"schema_version"`
-	NotificationSettings types.Object `tfsdk:"notification_settings"`
-	Evaluation           types.String `tfsdk:"evaluation"`
-	CreateAt             types.String `tfsdk:"create_at"`
-	CreateBy             types.String `tfsdk:"create_by"`
-	UpdateAt             types.String `tfsdk:"update_at"`
-	UpdateBy             types.String `tfsdk:"update_by"`
+	ID                   types.String               `tfsdk:"id"`
+	Alert                types.String               `tfsdk:"alert"`
+	AlertType            types.String               `tfsdk:"alert_type"`
+	BroadcastToAll       types.Bool                 `tfsdk:"broadcast_to_all"`
+	Condition            customtypes.NormalizedJSON `tfsdk:"condition"`
+	Description          types.String               `tfsdk:"description"`
+	Disabled             types.Bool                 `tfsdk:"disabled"`
+	EvalWindow           types.String               `tfsdk:"eval_window"`
+	Frequency            types.String               `tfsdk:"frequency"`
+	Labels               types.Map                  `tfsdk:"labels"`
+	PreferredChannels    types.List                 `tfsdk:"preferred_channels"`
+	RuleType             types.String               `tfsdk:"rule_type"`
+	Severity             types.String               `tfsdk:"severity"`
+	Source               types.String               `tfsdk:"source"`
+	State                types.String               `tfsdk:"state"`
+	Summary              types.String               `tfsdk:"summary"`
+	Version              types.String               `tfsdk:"version"`
+	SchemaVersion        types.String               `tfsdk:"schema_version"`
+	NotificationSettings types.Object               `tfsdk:"notification_settings"`
+	Evaluation           customtypes.NormalizedJSON `tfsdk:"evaluation"`
+	CreateAt             types.String               `tfsdk:"create_at"`
+	CreateBy             types.String               `tfsdk:"create_by"`
+	UpdateAt             types.String               `tfsdk:"update_at"`
+	UpdateBy             types.String               `tfsdk:"update_by"`
 }
 
 // Configure adds the provider configured client to the resource.
@@ -121,6 +122,7 @@ func (r *alertResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				DeprecationMessage: "This field is no longer needed and will be ignored",
 			},
 			attr.Condition: schema.StringAttribute{
+				CustomType:  customtypes.NormalizedJSONType{},
 				Required:    true,
 				Description: "Condition of the alert.",
 			},
@@ -258,6 +260,7 @@ func (r *alertResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				},
 			},
 			attr.Evaluation: schema.StringAttribute{
+				CustomType:  customtypes.NormalizedJSONType{},
 				Optional:    true,
 				Computed:    true,
 				Description: "Evaluation settings for the alert (JSON). Only used when schema_version is v2 or higher.",
@@ -320,7 +323,7 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 		SchemaVersion: plan.SchemaVersion.ValueString(),
 	}
 
-	err := alertPayload.SetCondition(plan.Condition)
+	err := alertPayload.SetCondition(types.StringValue(plan.Condition.ValueString()))
 	if err != nil {
 		addErr(&resp.Diagnostics, err, operationCreate, SigNozAlert)
 		return
@@ -335,7 +338,7 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	if !plan.Evaluation.IsNull() && plan.Evaluation.ValueString() != "" {
-		err := alertPayload.SetEvaluation(plan.Evaluation)
+		err := alertPayload.SetEvaluation(types.StringValue(plan.Evaluation.ValueString()))
 		if err != nil {
 			addErr(&resp.Diagnostics, err, operationCreate, SigNozAlert)
 			return
@@ -374,12 +377,14 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 	plan.UpdateAt = types.StringValue(alert.UpdateAt)
 	plan.UpdateBy = types.StringValue(alert.UpdateBy)
 
-	//As condition is JSON string, updated response contains extra keys
-	plan.Condition, err = alertPayload.ConditionToTerraform()
+	// condition/evaluation use customtypes.NormalizedJSON, whose semantic equality ignores the server's
+	// added empty/null keys and reordering — so storing the value as-is does not register as drift.
+	conditionTF, err := alertPayload.ConditionToTerraform()
 	if err != nil {
 		addErr(&resp.Diagnostics, err, operationCreate, SigNozAlert)
 		return
 	}
+	plan.Condition = customtypes.NewNormalizedJSONValue(conditionTF.ValueString())
 
 	var diagLabels diag.Diagnostics
 	plan.Labels, diagLabels = alert.LabelsToTerraform()
@@ -396,15 +401,15 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 		plan.NotificationSettings, diagLabels = alert.NotificationSettingsToTerraform(ctx)
 		resp.Diagnostics.Append(diagLabels...)
 
-		var evalErr error
-		plan.Evaluation, evalErr = alert.EvaluationToTerraform()
+		evaluationTF, evalErr := alert.EvaluationToTerraform()
 		if evalErr != nil {
 			addErr(&resp.Diagnostics, evalErr, operationCreate, SigNozAlert)
 		}
+		plan.Evaluation = customtypes.NewNormalizedJSONValue(evaluationTF.ValueString())
 	} else {
 		plan.NotificationSettings = types.ObjectNull(
 			attr.NotificationSettingsAttrTypes())
-		plan.Evaluation = types.StringNull()
+		plan.Evaluation = customtypes.NewNormalizedJSONNull()
 	}
 
 	// Set state to populated data.
@@ -459,11 +464,12 @@ func (r *alertResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	state.UpdateBy = types.StringValue(alert.UpdateBy)
 	state.SchemaVersion = types.StringValue(alert.SchemaVersion)
 
-	state.Condition, err = alert.ConditionToTerraform()
+	conditionTF, err := alert.ConditionToTerraform()
 	if err != nil {
 		addErr(&resp.Diagnostics, err, operationRead, SigNozAlert)
 		return
 	}
+	state.Condition = customtypes.NewNormalizedJSONValue(conditionTF.ValueString())
 
 	var diagLabelsRead diag.Diagnostics
 	state.Labels, diagLabelsRead = alert.LabelsToTerraform()
@@ -481,15 +487,16 @@ func (r *alertResource) Read(ctx context.Context, req resource.ReadRequest, resp
 			return
 		}
 
-		state.Evaluation, err = alert.EvaluationToTerraform()
-		if err != nil {
-			addErr(&resp.Diagnostics, err, operationRead, SigNozAlert)
+		evaluationTF, evalErr := alert.EvaluationToTerraform()
+		if evalErr != nil {
+			addErr(&resp.Diagnostics, evalErr, operationRead, SigNozAlert)
 			return
 		}
+		state.Evaluation = customtypes.NewNormalizedJSONValue(evaluationTF.ValueString())
 	} else {
 		state.NotificationSettings = types.ObjectNull(
 			attr.NotificationSettingsAttrTypes())
-		state.Evaluation = types.StringNull()
+		state.Evaluation = customtypes.NewNormalizedJSONNull()
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -536,7 +543,7 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		UpdateBy:       state.UpdateBy.ValueString(),
 	}
 
-	err = alertUpdate.SetCondition(plan.Condition)
+	err = alertUpdate.SetCondition(types.StringValue(plan.Condition.ValueString()))
 	if err != nil {
 		addErr(&resp.Diagnostics, err, operationUpdate, SigNozAlert)
 		return
@@ -553,7 +560,7 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	if !plan.Evaluation.IsNull() && plan.Evaluation.ValueString() != "" {
-		err := alertUpdate.SetEvaluation(plan.Evaluation)
+		err := alertUpdate.SetEvaluation(types.StringValue(plan.Evaluation.ValueString()))
 		if err != nil {
 			addErr(&resp.Diagnostics, err, operationUpdate, SigNozAlert)
 			return
@@ -598,12 +605,12 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	plan.UpdateAt = types.StringValue(alert.UpdateAt)
 	plan.UpdateBy = types.StringValue(alert.UpdateBy)
 
-	//As condition is JSON string, updated response contains extra keys
-	plan.Condition, err = alertUpdate.ConditionToTerraform()
+	conditionTF, err := alertUpdate.ConditionToTerraform()
 	if err != nil {
 		addErr(&resp.Diagnostics, err, operationUpdate, SigNozAlert)
 		return
 	}
+	plan.Condition = customtypes.NewNormalizedJSONValue(conditionTF.ValueString())
 
 	var diagLabelsUpdate diag.Diagnostics
 	plan.Labels, diagLabelsUpdate = alert.LabelsToTerraform()
@@ -621,15 +628,16 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 			return
 		}
 
-		plan.Evaluation, err = alert.EvaluationToTerraform()
-		if err != nil {
-			addErr(&resp.Diagnostics, err, operationUpdate, SigNozAlert)
+		evaluationTF, evalErr := alert.EvaluationToTerraform()
+		if evalErr != nil {
+			addErr(&resp.Diagnostics, evalErr, operationUpdate, SigNozAlert)
 			return
 		}
+		plan.Evaluation = customtypes.NewNormalizedJSONValue(evaluationTF.ValueString())
 	} else {
 		plan.NotificationSettings = types.ObjectNull(
 			attr.NotificationSettingsAttrTypes())
-		plan.Evaluation = types.StringNull()
+		plan.Evaluation = customtypes.NewNormalizedJSONNull()
 	}
 
 	// Set refreshed state.

--- a/signoz/internal/provider/resource/alert.go
+++ b/signoz/internal/provider/resource/alert.go
@@ -307,12 +307,15 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 			Summary:     plan.Summary.ValueString(),
 		},
 		BroadcastToAll: plan.BroadcastToAll.ValueBool(),
-		EvalWindow:     plan.EvalWindow.ValueString(),
-		Frequency:      plan.Frequency.ValueString(),
-		RuleType:       plan.RuleType.ValueString(),
-		Source:         plan.Source.ValueString(),
-		Version:        plan.Version.ValueString(),
-		SchemaVersion:  plan.SchemaVersion.ValueString(),
+		// Update sends Disabled in its payload; Create must too.
+		// Otherwise a `disabled = true` alert is created enabled, and the response (disabled=false) is inconsistent with the plan — which taints the resource and forces a destroy+recreate.
+		Disabled:      plan.Disabled.ValueBool(),
+		EvalWindow:    plan.EvalWindow.ValueString(),
+		Frequency:     plan.Frequency.ValueString(),
+		RuleType:      plan.RuleType.ValueString(),
+		Source:        plan.Source.ValueString(),
+		Version:       plan.Version.ValueString(),
+		SchemaVersion: plan.SchemaVersion.ValueString(),
 	}
 
 	err := alertPayload.SetCondition(plan.Condition)
@@ -358,6 +361,9 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 	plan.ID = types.StringValue(alert.ID)
 	plan.BroadcastToAll = types.BoolValue(alert.BroadcastToAll)
 	plan.Disabled = types.BoolValue(alert.Disabled)
+	// rule_type is Optional+Computed with no default, so it plans as "known after apply" when omitted from config.
+	// Like preferred_channels, Create must read it back from the response or it stays unknown after apply and churns the resource.
+	plan.RuleType = types.StringValue(alert.RuleType)
 	plan.Source = types.StringValue(alert.Source)
 	plan.State = types.StringValue(alert.State)
 	plan.SchemaVersion = types.StringValue(alert.SchemaVersion)
@@ -376,6 +382,13 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 	var diagLabels diag.Diagnostics
 	plan.Labels, diagLabels = alert.LabelsToTerraform()
 	resp.Diagnostics.Append(diagLabels...)
+
+	// preferred_channels is Optional+Computed, so it plans as "known after apply" when omitted from config.
+	// Create must populate it from the response, as Read and Update already do.
+	// Leaving it unknown makes Terraform reject the apply, taint the resource, and destroy+recreate it — churning the rule ID on every apply.
+	var diagPreferredChannels diag.Diagnostics
+	plan.PreferredChannels, diagPreferredChannels = alert.PreferredChannelsToTerraform()
+	resp.Diagnostics.Append(diagPreferredChannels...)
 
 	if alert.SchemaVersion != "" && alert.SchemaVersion != "v1" {
 		plan.NotificationSettings, diagLabels = alert.NotificationSettingsToTerraform(ctx)

--- a/signoz/internal/provider/resource/alert.go
+++ b/signoz/internal/provider/resource/alert.go
@@ -538,7 +538,7 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if !utils.IsNullOrUnknown(plan.NotificationSettings) {
 		err := alertUpdate.SetNotificationSettings(ctx, plan.NotificationSettings)
 		if err != nil {
-			addErr(&resp.Diagnostics, err, operationCreate, SigNozAlert)
+			addErr(&resp.Diagnostics, err, operationUpdate, SigNozAlert)
 			return
 		}
 	}
@@ -546,7 +546,7 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if !plan.Evaluation.IsNull() && plan.Evaluation.ValueString() != "" {
 		err := alertUpdate.SetEvaluation(plan.Evaluation)
 		if err != nil {
-			addErr(&resp.Diagnostics, err, operationCreate, SigNozAlert)
+			addErr(&resp.Diagnostics, err, operationUpdate, SigNozAlert)
 			return
 		}
 	}

--- a/signoz/internal/provider/resource/alert.go
+++ b/signoz/internal/provider/resource/alert.go
@@ -2,7 +2,9 @@ package resource
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
 
 	"github.com/SigNoz/terraform-provider-signoz/internal/apiclients"
@@ -426,6 +428,13 @@ func (r *alertResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	// Get refreshed alert from SigNoz.
 	alert, err := r.client.GetAlert(ctx, state.ID.ValueString())
 	if err != nil {
+		// If the alert was deleted out of band, drop it from state so Terraform plans a recreate
+		// instead of erroring on every subsequent plan/apply (and so destroy can proceed).
+		var apiErr *apiclients.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		addErr(&resp.Diagnostics, err, operationRead, SigNozAlert)
 		return
 	}
@@ -642,6 +651,11 @@ func (r *alertResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	// Delete existing alert.
 	err := r.client.DeleteAlert(ctx, state.ID.ValueString())
 	if err != nil {
+		// An already-deleted alert (404) is not an error — delete is idempotent.
+		var apiErr *apiclients.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return
+		}
 		addErr(&resp.Diagnostics, err, operationDelete, SigNozAlert)
 		return
 	}

--- a/tests/fixtures/channels.py
+++ b/tests/fixtures/channels.py
@@ -1,21 +1,39 @@
 """Seed the notification channels the example alerts and route policies reference.
 
-The examples route to channels named "slack" and "pagerduty". SigNoz validates
-that referenced channels exist, so they must be created before the CRUD cycle.
+SigNoz validates that a referenced channel exists, so every channel named in an example must be created
+before the CRUD cycle. Names are discovered from the example .tf files (plus a small base set the
+regression tests use) so new examples are covered automatically.
 """
+
+import re
 
 import pytest
 import requests
 
 from fixtures.logger import setup_logger
 from fixtures.signoz import SigNoz
+from fixtures.terraform import EXAMPLES
 
 logger = setup_logger(__name__)
 
-WEBHOOK_CHANNELS = ("slack", "pagerduty")
 WEBHOOK_URL = "https://example.com/webhook"
+# Always ensured, independent of the examples (used by the regression tests).
+BASE_CHANNELS = ("slack", "pagerduty")
 
 _TIMEOUT = 10
+_CHANNELS_RE = re.compile(r"channels\s*=\s*\[([^\]]*)\]")
+
+
+def _discover_channel_names() -> tuple[str, ...]:
+    """Return every channel name referenced by a `channels = [...]` block in the examples."""
+    names: set[str] = set(BASE_CHANNELS)
+    for tf_file in EXAMPLES.rglob("*.tf"):
+        for match in _CHANNELS_RE.findall(tf_file.read_text()):
+            for raw in match.split(","):
+                name = raw.strip().strip('"')
+                if name:
+                    names.add(name)
+    return tuple(sorted(names))
 
 
 def ensure_webhook_channel(signoz: SigNoz, name: str) -> None:
@@ -26,7 +44,6 @@ def ensure_webhook_channel(signoz: SigNoz, name: str) -> None:
     listing.raise_for_status()
     existing = {channel.get("name") for channel in (listing.json().get("data") or [])}
     if name in existing:
-        logger.info("notification channel %s already exists", name)
         return
 
     resp = requests.post(
@@ -41,8 +58,9 @@ def ensure_webhook_channel(signoz: SigNoz, name: str) -> None:
 
 @pytest.fixture(scope="session")
 def webhook_channels(signoz: SigNoz) -> tuple[str, ...]:
-    """Ensure the 'slack' and 'pagerduty' webhook channels exist for the examples."""
-    for name in WEBHOOK_CHANNELS:
+    """Ensure every channel referenced by the examples (and the base set) exists."""
+    names = _discover_channel_names()
+    for name in names:
         ensure_webhook_channel(signoz, name)
 
-    return WEBHOOK_CHANNELS
+    return names

--- a/tests/fixtures/terraform.py
+++ b/tests/fixtures/terraform.py
@@ -6,6 +6,7 @@ declares a `dev_overrides` block. dev_overrides bypass the registry and the
 local build.
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -124,3 +125,30 @@ class Terraform:
         result = self._run("destroy", "-auto-approve")
         assert result.returncode == 0, f"destroy failed:\n{result.stdout}\n{result.stderr}"
         return result
+
+    def state_resource(self, resource_type: str) -> dict:
+        """Return the attribute values of the first resource of the given type in the current state."""
+        result = self._run("show", "-json")
+        assert result.returncode == 0, f"show failed:\n{result.stdout}\n{result.stderr}"
+        state = json.loads(result.stdout)
+        for res in state.get("values", {}).get("root_module", {}).get("resources", []):
+            if res.get("type") == resource_type:
+                return res["values"]
+        raise AssertionError(f"no {resource_type} resource found in state")
+
+    def state_resource_id(self, resource_type: str) -> str:
+        return self.state_resource(resource_type)["id"]
+
+    def _run_raw(self, *args: str) -> subprocess.CompletedProcess:
+        """Like _run but without appending -no-color, for commands where flag position matters."""
+        result = subprocess.run([self.binary, *args], cwd=self.workdir, env=self.env, text=True, capture_output=True)
+        logger.info("terraform %s -> %d", " ".join(args), result.returncode)
+        return result
+
+    def state_rm(self, address: str) -> None:
+        result = self._run_raw("state", "rm", "-no-color", address)
+        assert result.returncode == 0, f"state rm failed:\n{result.stdout}\n{result.stderr}"
+
+    def import_resource(self, address: str, resource_id: str) -> None:
+        result = self._run_raw("import", "-no-color", "-input=false", address, resource_id)
+        assert result.returncode == 0, f"import failed:\n{result.stdout}\n{result.stderr}"

--- a/tests/fixtures/terraform.py
+++ b/tests/fixtures/terraform.py
@@ -115,6 +115,11 @@ class Terraform:
         assert result.returncode == 0, f"apply failed:\n{result.stdout}\n{result.stderr}"
         return result
 
+    def apply_expecting_failure(self) -> subprocess.CompletedProcess:
+        result = self._run("apply", "-auto-approve")
+        assert result.returncode != 0, f"expected apply to fail but it succeeded:\n{result.stdout}"
+        return result
+
     def plan_exit_code(self) -> int:
         # -detailed-exitcode: 0 = no changes, 1 = error, 2 = changes (drift).
         result = self._run("plan", "-detailed-exitcode")

--- a/tests/integration/tests/test_alert_rule_id_stability.py
+++ b/tests/integration/tests/test_alert_rule_id_stability.py
@@ -1,0 +1,225 @@
+"""Regression test: creating an alert must not churn its rule ID.
+
+The pre-fix provider left `preferred_channels` unknown after Create and ignored `disabled` in the
+create payload. Terraform therefore rejected the create result and tainted the freshly created
+alert, so the next apply destroyed and recreated it — assigning a brand new rule ID every time.
+That is what drove the "rule IDs keep changing" problem for downstream IaC (broken doc links,
+lost alert history). See resource/alert.go Create().
+
+This exercises the fix end to end: create succeeds, and a benign update is applied in place with
+the rule ID preserved rather than destroy+recreate.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from fixtures.signoz import SigNoz
+from fixtures.terraform import EXAMPLES, VERSIONS_TF, Terraform
+
+# A disabled traces alert that leaves the Optional+Computed attributes with no default
+# (preferred_channels AND rule_type) unset — the exact shape that tripped the bug: both plan as
+# "known after apply" and Create must repopulate them. `disabled = true` also exercises the
+# create-payload Disabled fix (and matches how our alerts are shipped: created disabled, enabled later).
+ALERT_TF = """\
+resource "signoz_alert" "churn" {
+  alert          = "rule-id stability regression"
+  alert_type     = "TRACES_BASED_ALERT"
+  description    = "__DESC__"
+  summary        = "rule-id stability regression"
+  severity       = "warning"
+  version        = "v5"
+  schema_version = "v2alpha1"
+  disabled       = true
+
+  condition = jsonencode({
+    compositeQuery = {
+      queryType = "builder"
+      panelType = "graph"
+      unit      = "ns"
+      queries = [{
+        type = "builder_query"
+        spec = {
+          name         = "A"
+          signal       = "traces"
+          stepInterval = 60
+          aggregations = [{ expression = "p99(duration_nano)" }]
+          filter       = { expression = "service.name = 'demo'" }
+        }
+      }]
+    }
+    selectedQueryName = "A"
+    thresholds = {
+      kind = "basic"
+      spec = [{
+        name       = "warning"
+        op         = "above"
+        matchType  = "at_least_once"
+        target     = 10
+        targetUnit = "s"
+        channels   = ["slack"]
+      }]
+    }
+  })
+
+  evaluation = jsonencode({
+    kind = "rolling"
+    spec = { evalWindow = "5m", frequency = "1m" }
+  })
+
+  notification_settings = {
+    group_by = ["service.name"]
+    renotify = {
+      enabled      = true
+      interval     = "30m"
+      alert_states = ["firing"]
+    }
+  }
+
+  labels = {
+    team = "regression"
+  }
+}
+"""
+
+
+def test_alert_rule_id_stable_across_update(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "before"))
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+
+    # Create. Pre-fix this fails: preferred_channels is unknown after apply, so Terraform taints the
+    # resource ("invalid result object after apply").
+    terraform.apply()
+    rule_id = terraform.state_resource_id("signoz_alert")
+    assert rule_id, "alert was not created"
+
+    try:
+        # A benign change. Pre-fix, the tainted resource is destroyed and recreated with a new id.
+        (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "after"))
+        terraform.apply()
+
+        assert terraform.state_resource_id("signoz_alert") == rule_id, (
+            "rule ID churned across an update (destroy+recreate instead of in-place)"
+        )
+    finally:
+        terraform.destroy()
+
+
+def test_alert_enable_disable_toggle(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """Enabling a disabled alert (disabled true -> false) must be in place, not a recreate.
+
+    This is the "ship the alert disabled, enable it later" workflow. Pre-fix, Create ignored disabled
+    in the payload, so the alert never actually landed disabled and the enable path was unreliable.
+    """
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "toggle"))  # disabled = true
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+
+    terraform.apply()
+    created = terraform.state_resource("signoz_alert")
+    assert created["disabled"] is True, "alert was not created disabled"
+    rule_id = created["id"]
+
+    try:
+        (workdir / "alert.tf").write_text(
+            ALERT_TF.replace("__DESC__", "toggle").replace("disabled       = true", "disabled       = false")
+        )
+        terraform.apply()
+
+        after = terraform.state_resource("signoz_alert")
+        assert after["disabled"] is False, "enabling the alert did not take effect"
+        assert after["id"] == rule_id, "enabling the alert churned the rule ID"
+    finally:
+        terraform.destroy()
+
+
+def test_alert_import_roundtrip(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """After importing an existing alert by id, reconciling must be in place — not a destroy+recreate."""
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "import"))
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+
+    terraform.apply()
+    rule_id = terraform.state_resource_id("signoz_alert")
+
+    try:
+        terraform.state_rm("signoz_alert.churn")
+        terraform.import_resource("signoz_alert.churn", rule_id)
+        # Applying against the imported state must reconcile in place, preserving the id.
+        terraform.apply()
+        assert terraform.state_resource_id("signoz_alert") == rule_id, (
+            "import round-trip replaced the resource (new rule ID)"
+        )
+    finally:
+        terraform.destroy()
+
+
+# The churn (unknown-value-after-apply) affected every alert type, not just traces. Assert each shipped
+# example creates without the "invalid result object after apply" error. Channel names are rewritten to a
+# channel that exists in the test env (examples reference environment-specific channels).
+_ALERT_EXAMPLES = sorted((EXAMPLES / "resources" / "signoz_alert").glob("*.tf"))
+_CREATE_SKIP = {"resource_anomaly.tf": 'API rejects rule_type "anomaly_rule" (unrelated to this fix)'}
+
+
+@pytest.mark.parametrize(
+    "example",
+    [
+        pytest.param(
+            p,
+            id=p.name,
+            marks=([pytest.mark.skip(reason=_CREATE_SKIP[p.name])] if p.name in _CREATE_SKIP else []),
+        )
+        for p in _ALERT_EXAMPLES
+    ],
+)
+def test_alert_example_creates_without_unknown_values(
+    example: Path,
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    src = re.sub(r"channels(\s*)=(\s*)\[[^\]]*\]", r'channels\1=\2["slack"]', example.read_text())
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / example.name).write_text(src)
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+
+    # Pre-fix this errors with "invalid result object after apply" (unknown preferred_channels/rule_type).
+    terraform.apply()
+    try:
+        assert terraform.state_resource_id("signoz_alert")
+    finally:
+        terraform.destroy()

--- a/tests/integration/tests/test_alert_rule_id_stability.py
+++ b/tests/integration/tests/test_alert_rule_id_stability.py
@@ -14,6 +14,7 @@ import re
 from pathlib import Path
 
 import pytest
+import requests
 
 from fixtures.signoz import SigNoz
 from fixtures.terraform import EXAMPLES, VERSIONS_TF, Terraform
@@ -265,5 +266,125 @@ def test_alert_update_error_reports_update_operation(
         output = result.stdout + result.stderr
         assert "failed to update" in output, f"update failure not labeled 'update':\n{output}"
         assert "failed to create" not in output, f"update failure mislabeled as 'create':\n{output}"
+    finally:
+        terraform.destroy()
+
+
+def _delete_alert_out_of_band(signoz: SigNoz, rule_id: str) -> None:
+    resp = requests.delete(
+        f"{signoz.endpoint}/api/v1/rules/{rule_id}",
+        headers={"SIGNOZ-API-KEY": signoz.access_token},
+        timeout=10,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_alert_read_recreates_after_out_of_band_delete(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """If the alert is deleted outside Terraform, a refresh must plan a recreate — not hard-error.
+
+    Read previously turned any GetAlert failure into an error, so a 404 wedged every future plan/apply.
+    """
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "oob-read"))
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+    terraform.apply()
+    rule_id = terraform.state_resource_id("signoz_alert")
+
+    try:
+        _delete_alert_out_of_band(signoz, rule_id)
+        # Refreshing must not error; it should detect the deletion and plan a recreate (exit code 2).
+        assert terraform.plan_exit_code() == 2, "expected a recreate plan after out-of-band deletion"
+        terraform.apply()
+        new_id = terraform.state_resource_id("signoz_alert")
+        assert new_id and new_id != rule_id, "alert was not recreated after out-of-band deletion"
+    finally:
+        terraform.destroy()
+
+
+def test_alert_destroy_tolerates_out_of_band_delete(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """`terraform destroy` must succeed even if the alert was already deleted out of band."""
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "oob-destroy"))
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+    terraform.apply()
+    rule_id = terraform.state_resource_id("signoz_alert")
+
+    _delete_alert_out_of_band(signoz, rule_id)
+    # Pre-fix, destroy's refresh hit a 404 and hard-errored, leaving the resource stuck in state.
+    terraform.destroy()
+
+
+def test_alert_preferred_channels_set_round_trips(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """Setting preferred_channels explicitly must round-trip and stay stable across an update."""
+    cfg = ALERT_TF.replace("__DESC__", "pc").replace(
+        "  disabled       = true", '  disabled       = true\n  preferred_channels = ["slack"]'
+    )
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(cfg)
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+    terraform.apply()
+    created = terraform.state_resource("signoz_alert")
+    assert created["preferred_channels"] == ["slack"], created["preferred_channels"]
+    rule_id = created["id"]
+
+    try:
+        (workdir / "alert.tf").write_text(cfg.replace('description    = "pc"', 'description    = "pc2"'))
+        terraform.apply()
+        assert terraform.state_resource_id("signoz_alert") == rule_id
+    finally:
+        terraform.destroy()
+
+
+def test_alert_condition_update_in_place(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """Changing the condition must update in place and preserve the rule ID."""
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "cond"))
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+    terraform.apply()
+    rule_id = terraform.state_resource_id("signoz_alert")
+
+    try:
+        # Change the threshold target inside the condition JSON.
+        changed = ALERT_TF.replace("__DESC__", "cond").replace("target     = 10", "target     = 12")
+        assert "target     = 12" in changed, "condition target anchor drifted from ALERT_TF"
+        (workdir / "alert.tf").write_text(changed)
+        terraform.apply()
+        assert terraform.state_resource_id("signoz_alert") == rule_id, "condition change churned the rule ID"
     finally:
         terraform.destroy()

--- a/tests/integration/tests/test_alert_rule_id_stability.py
+++ b/tests/integration/tests/test_alert_rule_id_stability.py
@@ -223,3 +223,47 @@ def test_alert_example_creates_without_unknown_values(
         assert terraform.state_resource_id("signoz_alert")
     finally:
         terraform.destroy()
+
+
+# The evaluation block from ALERT_TF, and a malformed replacement that makes SetEvaluation fail during
+# Update (evaluation is a plain string attribute with no schema validation, so it reaches the provider).
+_VALID_EVALUATION = """  evaluation = jsonencode({
+    kind = "rolling"
+    spec = { evalWindow = "5m", frequency = "1m" }
+  })"""
+_BROKEN_EVALUATION = '  evaluation = "{ not valid json"'
+
+
+def test_alert_update_error_reports_update_operation(
+    tmp_path: Path,
+    tf_cli_config: Path,
+    signoz: SigNoz,
+    terraform_bin: str,
+    webhook_channels: tuple[str, ...],
+):
+    """A failure during Update must be reported as an "update" error, not "create".
+
+    Two Update error paths (SetNotificationSettings / SetEvaluation) passed operationCreate to addErr,
+    so an update-time failure surfaced as "failed to create signoz_alert". This drives a real update
+    failure (malformed evaluation JSON) and asserts the diagnostic is labeled with the update operation.
+    """
+    assert _VALID_EVALUATION in ALERT_TF, "evaluation anchor drifted from ALERT_TF"
+
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / "versions.tf").write_text(VERSIONS_TF)
+    (workdir / "alert.tf").write_text(ALERT_TF.replace("__DESC__", "err"))
+
+    terraform = Terraform(workdir, tf_cli_config, signoz, terraform_bin)
+    terraform.apply()
+
+    try:
+        broken = ALERT_TF.replace("__DESC__", "err").replace(_VALID_EVALUATION, _BROKEN_EVALUATION)
+        (workdir / "alert.tf").write_text(broken)
+
+        result = terraform.apply_expecting_failure()
+        output = result.stdout + result.stderr
+        assert "failed to update" in output, f"update failure not labeled 'update':\n{output}"
+        assert "failed to create" not in output, f"update failure mislabeled as 'create':\n{output}"
+    finally:
+        terraform.destroy()

--- a/tests/integration/tests/test_examples.py
+++ b/tests/integration/tests/test_examples.py
@@ -11,11 +11,7 @@ RESOURCE_FILES = sorted((EXAMPLES / "resources").glob("signoz_*/*.tf"))
 # Example files to skip, keyed by "<resource>/<file>" -> reason. The integration
 # run surfaced provider/API issues for these.
 SKIPPED = {
-    "signoz_alert/resource.tf": "provider returns unknown values for computed fields after apply",
-    "signoz_alert/resource_logs_formula.tf": "provider returns unknown values for computed fields after apply",
-    "signoz_alert/resource_promql.tf": "provider returns unknown values for computed fields after apply",
-    "signoz_alert/resource_tiered.tf": "provider returns unknown values for computed fields after apply",
-    "signoz_alert/resource_traces_latency.tf": "provider returns unknown values for computed fields after apply",
+    # anomaly needs the rule_type allow-list AND the labels/severity round-trip fix (tracked separately).
     "signoz_alert/resource_anomaly.tf": 'provider rejects rule_type "anomaly_rule"',
     "signoz_dashboard/resource.tf": "provider produces an inconsistent result after apply",
     "signoz_planned_maintenance/resource.tf": "alert_ids reference non-existent rules (API 500)",


### PR DESCRIPTION
**Stacked on #118.** The churn fix there makes alerts create cleanly; this PR removes the *remaining* reason a `signoz_alert` plan is never a no-op. The first three commits belong to #118 — the substantive change here is the last commit, and the diff collapses to just that once #118 merges.

## Problem

`condition` and `evaluation` are plain JSON strings. The SigNoz API returns them with keys the config never sent — server-applied defaults (`source: ""`, `recoveryTarget: null`, `disabled: false`, `step: 0`) and reordered keys. So a refresh stores the server-enriched form, and every subsequent `terraform plan` shows a perpetual in-place update even when nothing changed. This is why the `signoz_alert` example CRUD tests were skipped (they assert a no-op plan) and why downstream users pin `condition` in `lifecycle.ignore_changes`.

## Fix

Add `customtypes.NormalizedJSON`, a string type whose `StringSemanticEquals` compares two JSON documents after normalizing away:
- key ordering and whitespace, and
- zero/empty-valued entries (`null`, `""`, `false`, `0`, `{}`, `[]`) — the shape of the server's added defaults.

`condition`/`evaluation` use this type, so the config and the server-enriched form compare equal and a no-op plan is a genuine no-op. **Real changes still diff**: changing a value leaves the other side carrying the previous value, so equality fails and the change is shown. Equality is deliberately symmetric (normalize both sides, then deep-equal), not a "config ⊆ server" subset check — a subset check would silently swallow field *removals*.

## Testing

- Unit tests for `StringSemanticEquals` (18 cases): server-added defaults equal; real value changes, changes to/from zero, array length/order, and different keys not equal; invalid JSON falls back to string comparison.
- Re-enables the 5 previously-skipped `signoz_alert` example CRUD tests — they now pass the full create → **no-op plan** → destroy cycle across metric/PromQL/logs/tiered/traces. The channels fixture now seeds every channel the examples reference.
- Verified against a live SigNoz: the no-op plan is clean for every alert type, and a real `target` change is still detected with the ruleId preserved.

`anomaly` stays skipped (needs the `rule_type` allow-list plus a labels/severity round-trip fix, tracked separately).

## Note for maintainers

Treating `0`/`false` as "absent" for equality is intentional — the API fills omitted condition fields with their zero value — but it is a judgment call. Happy to scope normalization to `null`/empty-string/empty-container only if you prefer the more conservative rule, at the cost of PromQL alerts still showing drift.
