### PR TITLE
ci(postci): remove safe-to-test on fork/dependabot PR sync

### DIFF
--- a/.github/workflows/postci.yml
+++ b/.github/workflows/postci.yml
@@ -1,0 +1,18 @@
+name: postci
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - synchronize
+
+jobs:
+  remove:
+    if: github.event.pull_request.head.repo.fork || github.event.pull_request.user.login == 'dependabot[bot]'
+    uses: signoz/primus.workflows/.github/workflows/github-label.yaml@main
+    secrets: inherit
+    with:
+      PRIMUS_REF: main
+      GITHUB_LABEL_ACTION: remove
+      GITHUB_LABEL_NAME: safe-to-test


### PR DESCRIPTION
#### Chores

- Add a `postci` workflow that auto-removes the `safe-to-test` label whenever a fork or `dependabot[bot]` PR is synchronized with new commits, forcing a maintainer to re-review and re-label before privileged CI runs again. Ports the workflow from the upstream `SigNoz/signoz` repo. It is a thin caller of the `signoz/primus.workflows` `github-label` reusable workflow (auth handled inside it via the primus GitHub App token, so no caller `permissions` block is needed).
