### PR TITLE
fix(rule): accept empty metric enum values (#132)

### DIFF
--- a/internal/apiclients/zz_generated_client.go
+++ b/internal/apiclients/zz_generated_client.go
@@ -2572,8 +2572,8 @@ type GetRoleResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
-		Data   apitypes.AuthtypesRoleWithTransactionGroups `json:"data"`
-		Status string                                      `json:"status"`
+		Data   apitypes.AuthtypesRole `json:"data"`
+		Status string                 `json:"status"`
 	}
 	JSON401 *apitypes.RenderErrorResponse
 	JSON403 *apitypes.RenderErrorResponse
@@ -4380,8 +4380,8 @@ func ParseGetRoleResponse(rsp *http.Response) (*GetRoleResponse, error) {
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
-			Data   apitypes.AuthtypesRoleWithTransactionGroups `json:"data"`
-			Status string                                      `json:"status"`
+			Data   apitypes.AuthtypesRole `json:"data"`
+			Status string                 `json:"status"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/apitypes/zz_generated_authtypes_role.go
+++ b/internal/apitypes/zz_generated_authtypes_role.go
@@ -9,11 +9,12 @@ import (
 
 // AuthtypesRole defines model for AuthtypesRole.
 type AuthtypesRole struct {
-	CreatedAt   *time.Time `json:"createdAt,omitempty"`
-	Description string     `json:"description"`
-	Id          string     `json:"id"`
-	Name        string     `json:"name"`
-	OrgId       string     `json:"orgId"`
-	Type        string     `json:"type"`
-	UpdatedAt   *time.Time `json:"updatedAt,omitempty"`
+	CreatedAt         *time.Time                 `json:"createdAt,omitempty"`
+	Description       string                     `json:"description"`
+	Id                string                     `json:"id"`
+	Name              string                     `json:"name"`
+	OrgId             string                     `json:"orgId"`
+	TransactionGroups AuthtypesTransactionGroups `json:"transactionGroups"`
+	Type              string                     `json:"type"`
+	UpdatedAt         *time.Time                 `json:"updatedAt,omitempty"`
 }

--- a/internal/apitypes/zz_generated_metrictypes_temporality.go
+++ b/internal/apitypes/zz_generated_metrictypes_temporality.go
@@ -7,6 +7,7 @@ package apitypes
 const (
 	MetrictypesTemporalityCumulative  MetrictypesTemporality = "cumulative"
 	MetrictypesTemporalityDelta       MetrictypesTemporality = "delta"
+	MetrictypesTemporalityEmpty       MetrictypesTemporality = ""
 	MetrictypesTemporalityUnspecified MetrictypesTemporality = "unspecified"
 )
 
@@ -16,6 +17,8 @@ func (e MetrictypesTemporality) Valid() bool {
 	case MetrictypesTemporalityCumulative:
 		return true
 	case MetrictypesTemporalityDelta:
+		return true
+	case MetrictypesTemporalityEmpty:
 		return true
 	case MetrictypesTemporalityUnspecified:
 		return true

--- a/internal/apitypes/zz_generated_metrictypes_time_aggregation.go
+++ b/internal/apitypes/zz_generated_metrictypes_time_aggregation.go
@@ -8,6 +8,7 @@ const (
 	MetrictypesTimeAggregationAvg           MetrictypesTimeAggregation = "avg"
 	MetrictypesTimeAggregationCount         MetrictypesTimeAggregation = "count"
 	MetrictypesTimeAggregationCountDistinct MetrictypesTimeAggregation = "count_distinct"
+	MetrictypesTimeAggregationEmpty         MetrictypesTimeAggregation = ""
 	MetrictypesTimeAggregationIncrease      MetrictypesTimeAggregation = "increase"
 	MetrictypesTimeAggregationLatest        MetrictypesTimeAggregation = "latest"
 	MetrictypesTimeAggregationMax           MetrictypesTimeAggregation = "max"
@@ -24,6 +25,8 @@ func (e MetrictypesTimeAggregation) Valid() bool {
 	case MetrictypesTimeAggregationCount:
 		return true
 	case MetrictypesTimeAggregationCountDistinct:
+		return true
+	case MetrictypesTimeAggregationEmpty:
 		return true
 	case MetrictypesTimeAggregationIncrease:
 		return true

--- a/internal/apitypes/zz_generated_telemetrytypes_source.go
+++ b/internal/apitypes/zz_generated_telemetrytypes_source.go
@@ -5,12 +5,15 @@ package apitypes
 
 // Defines values for TelemetrytypesSource.
 const (
+	TelemetrytypesSourceEmpty TelemetrytypesSource = ""
 	TelemetrytypesSourceMeter TelemetrytypesSource = "meter"
 )
 
 // Valid indicates whether the value is a known member of the TelemetrytypesSource enum.
 func (e TelemetrytypesSource) Valid() bool {
 	switch e {
+	case TelemetrytypesSourceEmpty:
+		return true
 	case TelemetrytypesSourceMeter:
 		return true
 	default:

--- a/internal/convertors/zz_generated_role_flex.go
+++ b/internal/convertors/zz_generated_role_flex.go
@@ -46,7 +46,7 @@ func ExpandAuthtypesUpdatableRole(ctx context.Context, m schemas.RoleModel) (*ap
 	return out, diags
 }
 
-func FlattenAuthtypesRoleWithTransactionGroups(ctx context.Context, g *apitypes.AuthtypesRoleWithTransactionGroups) (*schemas.RoleDataSourceModel, diag.Diagnostics) {
+func FlattenAuthtypesRole(ctx context.Context, g *apitypes.AuthtypesRole) (*schemas.RoleDataSourceModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if g == nil {
 		return nil, diags

--- a/internal/schemas/zz_generated_dashboard_resource.go
+++ b/internal/schemas/zz_generated_dashboard_resource.go
@@ -1967,6 +1967,7 @@ func DashboardResourceSchema(ctx context.Context) schema.Schema {
 																								Validators: []validator.String{
 																									stringvalidator.OneOf(
 																										"meter",
+																										"",
 																									),
 																								},
 																							},
@@ -2051,6 +2052,7 @@ func DashboardResourceSchema(ctx context.Context) schema.Schema {
 																													"delta",
 																													"cumulative",
 																													"unspecified",
+																													"",
 																												),
 																											},
 																										},
@@ -2068,6 +2070,7 @@ func DashboardResourceSchema(ctx context.Context) schema.Schema {
 																													"count_distinct",
 																													"rate",
 																													"increase",
+																													"",
 																												),
 																											},
 																										},
@@ -2632,6 +2635,7 @@ func DashboardResourceSchema(ctx context.Context) schema.Schema {
 																								Validators: []validator.String{
 																									stringvalidator.OneOf(
 																										"meter",
+																										"",
 																									),
 																								},
 																							},
@@ -3223,6 +3227,7 @@ func DashboardResourceSchema(ctx context.Context) schema.Schema {
 																								Validators: []validator.String{
 																									stringvalidator.OneOf(
 																										"meter",
+																										"",
 																									),
 																								},
 																							},
@@ -4108,6 +4113,7 @@ func DashboardResourceSchema(ctx context.Context) schema.Schema {
 																															Validators: []validator.String{
 																																stringvalidator.OneOf(
 																																	"meter",
+																																	"",
 																																),
 																															},
 																														},
@@ -4192,6 +4198,7 @@ func DashboardResourceSchema(ctx context.Context) schema.Schema {
 																																				"delta",
 																																				"cumulative",
 																																				"unspecified",
+																																				"",
 																																			),
 																																		},
 																																	},
@@ -4209,6 +4216,7 @@ func DashboardResourceSchema(ctx context.Context) schema.Schema {
 																																				"count_distinct",
 																																				"rate",
 																																				"increase",
+																																				"",
 																																			),
 																																		},
 																																	},
@@ -4773,6 +4781,7 @@ func DashboardResourceSchema(ctx context.Context) schema.Schema {
 																															Validators: []validator.String{
 																																stringvalidator.OneOf(
 																																	"meter",
+																																	"",
 																																),
 																															},
 																														},
@@ -5364,6 +5373,7 @@ func DashboardResourceSchema(ctx context.Context) schema.Schema {
 																															Validators: []validator.String{
 																																stringvalidator.OneOf(
 																																	"meter",
+																																	"",
 																																),
 																															},
 																														},

--- a/internal/schemas/zz_generated_rule_resource.go
+++ b/internal/schemas/zz_generated_rule_resource.go
@@ -862,6 +862,7 @@ func RuleResourceSchema(ctx context.Context) schema.Schema {
 																	Validators: []validator.String{
 																		stringvalidator.OneOf(
 																			"meter",
+																			"",
 																		),
 																	},
 																},
@@ -946,6 +947,7 @@ func RuleResourceSchema(ctx context.Context) schema.Schema {
 																						"delta",
 																						"cumulative",
 																						"unspecified",
+																						"",
 																					),
 																				},
 																			},
@@ -963,6 +965,7 @@ func RuleResourceSchema(ctx context.Context) schema.Schema {
 																						"count_distinct",
 																						"rate",
 																						"increase",
+																						"",
 																					),
 																				},
 																			},
@@ -1527,6 +1530,7 @@ func RuleResourceSchema(ctx context.Context) schema.Schema {
 																	Validators: []validator.String{
 																		stringvalidator.OneOf(
 																			"meter",
+																			"",
 																		),
 																	},
 																},
@@ -2118,6 +2122,7 @@ func RuleResourceSchema(ctx context.Context) schema.Schema {
 																	Validators: []validator.String{
 																		stringvalidator.OneOf(
 																			"meter",
+																			"",
 																		),
 																	},
 																},

--- a/internal/services/zz_generated_role_data_source.go
+++ b/internal/services/zz_generated_role_data_source.go
@@ -68,7 +68,7 @@ func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 	out := &httpResp.JSON200.Data
 
-	next, diags := conv.FlattenAuthtypesRoleWithTransactionGroups(ctx, out)
+	next, diags := conv.FlattenAuthtypesRole(ctx, out)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/zz_generated_role_resource.go
+++ b/internal/services/zz_generated_role_resource.go
@@ -91,7 +91,7 @@ func (r *roleResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 	out := &getResp.JSON200.Data
 
-	next, diags := conv.FlattenAuthtypesRoleWithTransactionGroups(ctx, out)
+	next, diags := conv.FlattenAuthtypesRole(ctx, out)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -127,7 +127,7 @@ func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 	out := &httpResp.JSON200.Data
 
-	next, diags := conv.FlattenAuthtypesRoleWithTransactionGroups(ctx, out)
+	next, diags := conv.FlattenAuthtypesRole(ctx, out)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -176,7 +176,7 @@ func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 	out := &getResp.JSON200.Data
 
-	next, diags := conv.FlattenAuthtypesRoleWithTransactionGroups(ctx, out)
+	next, diags := conv.FlattenAuthtypesRole(ctx, out)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/tests/testdata/resources/signoz_rule/07/01-empty_metric_enums.tf
+++ b/tests/testdata/resources/signoz_rule/07/01-empty_metric_enums.tf
@@ -1,0 +1,72 @@
+resource "signoz_rule" "scenario_07" {
+  alert      = "testdata-empty-metric-enums"
+  alert_type = "METRIC_BASED_ALERT"
+  rule_type  = "threshold_rule"
+
+  condition = {
+    composite_query = {
+      panel_type = "table"
+      query_type = "builder"
+      unit       = "percent"
+
+      queries = [
+        {
+          builder_query = {
+            type = "builder_query"
+            spec = {
+              metrics = {
+                name   = "A"
+                signal = "metrics"
+                source = ""
+
+                aggregations = [
+                  {
+                    metric_name       = "system.memory.utilization"
+                    space_aggregation = "avg"
+                    time_aggregation  = ""
+                    temporality       = ""
+                  }
+                ]
+
+                filter = {
+                  expression = "state = 'free'"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+
+    selected_query_name = "A"
+
+    thresholds = {
+      basic = {
+        kind = "basic"
+        spec = [
+          {
+            channels   = ["slack"]
+            match_type = "on_average"
+            name       = "low free memory"
+            op         = "below"
+            target     = 10
+          }
+        ]
+      }
+    }
+  }
+
+  evaluation = {
+    rolling = {
+      kind = "rolling"
+      spec = {
+        eval_window = "10m"
+        frequency   = "5m"
+      }
+    }
+  }
+
+  notification_settings = {}
+
+  schema_version = "v2alpha1"
+}


### PR DESCRIPTION
#### Fixes

- Empty `source` / `temporality` / `time_aggregation` on a metric builder query no longer fail with `Invalid Attribute Value Match` (#132). `terraform import` + `terraform plan -generate-config-out` emits these empty enum values for unset fields; the regenerated schema now accepts `""`, matching SigNoz [#12164](https://github.com/SigNoz/signoz/pull/12164). Same fix lands on `signoz_dashboard`'s metric tree.

#### Chores

- Regenerate the provider by re-running skaff against `SigNoz/signoz` main **3-way merged with the rules-v2alpha1 OpenAPI contract** ([#12112](https://github.com/SigNoz/signoz/pull/12112)). Using the #12112 contract keeps `signoz_rule` at its intended v2alpha1 shape instead of main's intermediate rule schema (which had re-added condition-level `match_type`/`op`), so the only `signoz_rule` change here is the empty-enum fix. The regen also refreshes the `signoz_role` apitypes/client to main's current role spec.

#### Tests

- Add a `signoz_rule` testdata scenario whose metric query carries the empty `source`/`temporality`/`time_aggregation` values a generated config produces, verifying they now validate and round-trip.
