### PR TITLE
docs: rework signoz_dashboard v1→v2 upgrade guide

### DIFF
--- a/docs/guides/v0.0.x-to-v0.1.0.md
+++ b/docs/guides/v0.0.x-to-v0.1.0.md
@@ -7,51 +7,24 @@ description: |-
 
 # SigNoz Provider v0.0.x to v0.1.0 Upgrade Guide
 
-Version **v0.1.0** completes the SigNoz provider's move to fully typed,
-schema-driven resources generated from the SigNoz OpenAPI spec. Every attribute
-is now a first-class field that Terraform can plan, validate, and diff — there
-are no more opaque `jsonencode(...)` blobs.
+Version **v0.1.0** completes the SigNoz provider's move to fully typed, schema-driven resources generated from the SigNoz OpenAPI spec. Every attribute is now a first-class field that Terraform can plan, validate, and diff — there are no more opaque `jsonencode(...)` blobs.
 
 Two changes are **breaking** and need action before or during the upgrade:
 
-1. [`signoz_alert` has been removed](#signoz_alert-removed) — use `signoz_rule`.
-2. [`signoz_dashboard` moved to a typed v2 schema](#signoz_dashboard-v1-to-v2) —
-   the old JSON-string configuration must be migrated.
+1. [`signoz_alert` has been removed](#signoz_alert-removed) - use `signoz_rule`.
+2. [`signoz_dashboard` moved to a typed v2 schema](#signoz_dashboard-v1-to-v2) - the old JSON-string configuration must be migrated.
 
 If you use neither resource, upgrading to v0.1.0 needs no configuration changes.
 
 ## `signoz_alert` removed
 
-`signoz_alert` — built on the SigNoz v1 rules API, with `condition` and
-`evaluation` carried as opaque `jsonencode(...)` strings — has been removed. Its
-replacement is [`signoz_rule`](../resources/rule): the same alert rules on the
-**v2 rules API** (`/api/v2/rules`, `schema_version = "v2alpha1"`), with every
-field typed and validated at plan time.
-
-The rule data on the server is untouched — the v1 and v2 APIs are two views over
-one rule store — so this is a Terraform resource-*type* change, not a rule
-rewrite. Terraform can generate the typed `signoz_rule` configuration for you
-from the live rule using an `import` block and `-generate-config-out`.
-
-Migrate each rule while still on a v0.0.x provider (where `signoz_alert` still
-exists), then upgrade to v0.1.0. The dedicated [**Migrating from `signoz_alert`
-to `signoz_rule`**](migrate-signoz-alert-to-signoz-rule) guide has the full
-step-by-step workflow and the attribute-by-attribute mapping.
+Migrate each rule while still on a v0.0.x provider (where `signoz_alert` still exists), then upgrade to v0.1.0. The dedicated [**Migrating from `signoz_alert` to `signoz_rule`**](migrate-signoz-alert-to-signoz-rule) guide has the full step-by-step workflow and the attribute-by-attribute mapping.
 
 ## `signoz_dashboard` v1 to v2
 
-v0.1.0 replaces the `signoz_dashboard` resource and data source with a new
-implementation built on the SigNoz dashboards **v2 API** (`/api/v2/dashboards`),
-available in **SigNoz v0.135.0 and newer**. The new schema models a dashboard as
-a fully typed [Perses](https://perses.dev) specification instead of opaque JSON
-strings, so every panel, query, variable, and grid layout is a first-class
-attribute Terraform validates at plan time.
+v0.1.0 replaces the `signoz_dashboard` resource and data source with a new implementation built on the SigNoz dashboards **v2 API** (`/api/v2/dashboards`), available in **SigNoz v0.135.0 and newer**. The new schema models a dashboard as a fully typed [Perses](https://perses.dev) specification instead of opaque JSON strings, so every panel, query, variable, and grid layout is a first-class attribute Terraform validates at plan time.
 
-~> **This is a breaking change.** The resource's entire attribute set changed, so
-existing configurations and state must be migrated. The dashboard data on the
-server is untouched — importing adopts the existing dashboard by ID — so this is
-a Terraform resource *schema* change, not a dashboard rewrite, and Terraform can
-generate the new typed configuration for you.
+~> **This is a breaking change.** The resource's entire attribute set changed, so existing configurations and state must be migrated. Terraform can generate the new typed configuration for you.
 
 ### What changed
 
@@ -73,9 +46,7 @@ resource "signoz_dashboard" "old" {
 }
 ```
 
-The v2 resource replaces those with a typed tree under `spec`, so every panel,
-query, variable, and layout is a first-class attribute that Terraform can plan
-and validate:
+The v2 resource replaces those with a typed tree under `spec`, so every panel, query, variable, and layout is a first-class attribute that Terraform can plan and validate:
 
 ```terraform
 resource "signoz_dashboard" "new" {
@@ -93,14 +64,13 @@ resource "signoz_dashboard" "new" {
     }
 
     variables = [/* typed list/text variables */]
-    panels    = { /* keyed by panel UUID */ }
+    panels    = { /* keyed by panel names */ }
     layouts   = [/* grid layouts referencing panels by $ref */]
   }
 }
 ```
 
-See the [`signoz_dashboard` resource documentation](../resources/dashboard) for a
-complete, working example.
+See the [`signoz_dashboard` resource documentation](../resources/dashboard) for a complete, working example.
 
 ### Before you begin
 
@@ -117,23 +87,16 @@ complete, working example.
 
 ### Recommended: let Terraform generate the typed config
 
-Because the v2 `signoz_dashboard` implements import plus a full typed read (a `GET`
-on the v2 API mapped into the typed model), Terraform can write the v2 HCL for you
-with `-generate-config-out`. This is the easiest and least error-prone path — the
-generated config is schema-correct by construction and matches the live dashboard.
+Because the v2 `signoz_dashboard` implements import plus a full typed read (a `GET` on the v2 API mapped into the typed model), Terraform can write the v2 HCL for you with `-generate-config-out`. This is the easiest and least error-prone path — the generated config is schema-correct by construction and matches the live dashboard.
 
-For each dashboard (`<name>` = the resource label, `<dashboard-id>` = the ID you
-recorded):
+For each dashboard (`<name>` = the resource label, `<dashboard-id>` = the ID you recorded):
 
-1. **Remove the old resource from state.** This is a resource-*schema* change, not
-   an in-place upgrade, so the v1 entry has to leave state first:
-
+1. **Remove the old resource from state.** This is a resource-*schema* change, not an in-place upgrade, so the v1 entry has to leave state first:
    ```sh
    terraform state rm signoz_dashboard.<name>
    ```
 
 2. **Add an `import` block** pointing the resource at the existing dashboard ID:
-
    ```terraform
    # migrate.tf — delete once migration is done
    import {
@@ -150,7 +113,6 @@ recorded):
    ```
 
 4. **Execute the import:**
-
    ```sh
    terraform apply
    ```
@@ -164,34 +126,26 @@ recorded):
      panel/query tree is worth eyeballing.
 
 6. **Confirm no drift:**
-
    ```sh
    terraform plan   # should report: No changes
    ```
 
-Repeat per dashboard until every v1 `signoz_dashboard` block is gone from your
-configuration.
+Repeat per dashboard until every v1 `signoz_dashboard` block is gone from your configuration.
 
--> The generated config is emitted directly from what the v2 API returns, so it is
-always a valid v2 dashboard. If step 6 shows a diff, treat it as real drift (or a
-bug to report) rather than editing blindly.
+-> The generated config is emitted directly from what the v2 API returns, so it is always a valid v2 dashboard. If step 6 shows a diff, treat it as real drift (or a bug to report) rather than editing blindly.
 
 ### Alternative: rewrite the config by hand
 
-If you would rather translate the config yourself — or you are authoring a new
-`signoz_dashboard` from an old one you have on file — keep the `import` step (steps
-1-2 and 4 above): the dashboard still needs to be adopted by ID; only the config for
-step 3 is written by hand instead of generated. The attribute mapping is:
+If you would rather translate the config yourself — or you are authoring a new `signoz_dashboard` from an old one you have on file — keep the `import` step (steps 1-2 and 4 above): the dashboard still needs to be adopted by ID; only the config for step 3 is written by hand instead of generated. The attribute mapping is:
 
 | old (v1)                                                               | new (v2)                                                |
 | ---------------------------------------------------------------------- | ------------------------------------------------------- |
 | `title`, `description`                                                 | `spec.display.name`, `spec.display.description`         |
 | `tags` (list of strings)                                               | `tags` (list of `{ key, value }` objects)               |
-| `widgets` (JSON string)                                                | `spec.panels` (map of typed panels, keyed by UUID)      |
+| `widgets` (JSON string)                                                | `spec.panels` (map of typed panels, keyed by panel name) |
 | `layout` (JSON string)                                                 | `spec.layouts` (list of typed grid layouts)             |
 | `variables` (JSON string)                                              | `spec.variables` (list of typed list/text variables)    |
 | `version`                                                              | `schema_version` (set to `"v6"`)                        |
 | `panel_map`, `collapsable_rows_migrated`, `uploaded_grafana`, `source` | removed (folded into `spec.layouts` / no longer needed) |
 
-Because the `spec` tree is large and deeply nested, hand-authoring is error-prone;
-the generated-config path above is strongly recommended.
+Because the `spec` tree is large and deeply nested, hand-authoring is error-prone; the generated-config path above is strongly recommended.

--- a/docs/guides/v0.0.x-to-v0.1.0.md
+++ b/docs/guides/v0.0.x-to-v0.1.0.md
@@ -16,7 +16,7 @@ Two changes are **breaking** and need action before or during the upgrade:
 
 1. [`signoz_alert` has been removed](#signoz_alert-removed) — use `signoz_rule`.
 2. [`signoz_dashboard` moved to a typed v2 schema](#signoz_dashboard-v1-to-v2) —
-   the old JSON-string configuration must be rewritten.
+   the old JSON-string configuration must be migrated.
 
 If you use neither resource, upgrading to v0.1.0 needs no configuration changes.
 
@@ -41,11 +41,17 @@ step-by-step workflow and the attribute-by-attribute mapping.
 ## `signoz_dashboard` v1 to v2
 
 v0.1.0 replaces the `signoz_dashboard` resource and data source with a new
-implementation built on the SigNoz dashboards **v2 API** (`/api/v2/dashboards`).
-The new schema models a dashboard as a fully typed [Perses](https://perses.dev)
-specification instead of opaque JSON strings. This is a **breaking change**: the
-resource's entire attribute set changed, so existing configurations and state
-must be migrated.
+implementation built on the SigNoz dashboards **v2 API** (`/api/v2/dashboards`),
+available in **SigNoz v0.135.0 and newer**. The new schema models a dashboard as
+a fully typed [Perses](https://perses.dev) specification instead of opaque JSON
+strings, so every panel, query, variable, and grid layout is a first-class
+attribute Terraform validates at plan time.
+
+~> **This is a breaking change.** The resource's entire attribute set changed, so
+existing configurations and state must be migrated. The dashboard data on the
+server is untouched — importing adopts the existing dashboard by ID — so this is
+a Terraform resource *schema* change, not a dashboard rewrite, and Terraform can
+generate the new typed configuration for you.
 
 ### What changed
 
@@ -96,39 +102,96 @@ resource "signoz_dashboard" "new" {
 See the [`signoz_dashboard` resource documentation](../resources/dashboard) for a
 complete, working example.
 
-#### Attribute mapping
+### Before you begin
 
-| old (v1)                                                     | new (v2)                                                   |
-| ------------------------------------------------------------ | ---------------------------------------------------------- |
-| `title`, `description`                                       | `spec.display.name`, `spec.display.description`            |
-| `tags` (list of strings)                                     | `tags` (list of `{ key, value }` objects)                  |
-| `widgets` (JSON string)                                      | `spec.panels` (map of typed panels, keyed by UUID)         |
-| `layout` (JSON string)                                       | `spec.layouts` (list of typed grid layouts)                |
-| `variables` (JSON string)                                    | `spec.variables` (list of typed list/text variables)       |
-| `version`                                                    | `schema_version`                                           |
-| `panel_map`, `collapsable_rows_migrated`, `uploaded_grafana` | removed (folded into `spec.layouts` / no longer needed)    |
+- **Terraform 1.5 or newer**, for the recommended import-block workflow (`import {}` + `-generate-config-out`).
+- **SigNoz v0.135.0 or newer**, which exposes the dashboards v2 API.
+- The dashboard already exists on the server. Importing adopts it by ID — no dashboard is created, deleted, or interrupted during migration.
+- **Record each dashboard's ID first.** You need it to import, and it leaves state when you remove the old resource:
 
-### Upgrade steps
+  ```sh
+  terraform state show signoz_dashboard.<name>   # copy the `id` value
+  ```
 
-Because the schema changed completely, there is no in-place attribute rename — the
-configuration has to be rewritten:
+-> SigNoz is migrating legacy v1 dashboards to the v2 schema on the server side (see [SigNoz/signoz#12177](https://github.com/SigNoz/signoz/issues/12177)). Once a dashboard is available through the v2 API, the workflow below generates its typed config directly.
 
-1. **Remove the old resource from state** so Terraform stops tracking the v1 shape:
+### Recommended: let Terraform generate the typed config
+
+Because the v2 `signoz_dashboard` implements import plus a full typed read (a `GET`
+on the v2 API mapped into the typed model), Terraform can write the v2 HCL for you
+with `-generate-config-out`. This is the easiest and least error-prone path — the
+generated config is schema-correct by construction and matches the live dashboard.
+
+For each dashboard (`<name>` = the resource label, `<dashboard-id>` = the ID you
+recorded):
+
+1. **Remove the old resource from state.** This is a resource-*schema* change, not
+   an in-place upgrade, so the v1 entry has to leave state first:
 
    ```sh
    terraform state rm signoz_dashboard.<name>
    ```
 
-2. **Rewrite the configuration** using the v2 schema (see the resource documentation
-   and example).
+2. **Add an `import` block** pointing the resource at the existing dashboard ID:
 
-3. **Import the existing dashboard** back into state under the new schema:
-
-   ```sh
-   terraform import signoz_dashboard.<name> <dashboard-id>
+   ```terraform
+   # migrate.tf — delete once migration is done
+   import {
+     to = signoz_dashboard.<name>
+     id = "<dashboard-id>"
+   }
    ```
 
-4. Run `terraform plan` and reconcile any remaining differences.
+3. **Generate the typed config.** Terraform reads the dashboard through the v2 API
+   and writes the full typed `signoz_dashboard` block:
 
-Alternatively, if you manage dashboards as code and can recreate them, delete the old
-dashboards and apply the new configuration from scratch.
+   ```sh
+   terraform plan -generate-config-out=generated.tf
+   ```
+
+4. **Execute the import:**
+
+   ```sh
+   terraform apply
+   ```
+
+5. **Clean up.** Move the block from `generated.tf` into your real configuration,
+   then:
+   - delete the old `signoz_dashboard` block from your config,
+   - delete `migrate.tf` and `generated.tf`,
+   - trim the generated block if you like. `-generate-config-out` emits every
+     optional and computed attribute, so it is verbose; the deeply nested
+     panel/query tree is worth eyeballing.
+
+6. **Confirm no drift:**
+
+   ```sh
+   terraform plan   # should report: No changes
+   ```
+
+Repeat per dashboard until every v1 `signoz_dashboard` block is gone from your
+configuration.
+
+-> The generated config is emitted directly from what the v2 API returns, so it is
+always a valid v2 dashboard. If step 6 shows a diff, treat it as real drift (or a
+bug to report) rather than editing blindly.
+
+### Alternative: rewrite the config by hand
+
+If you would rather translate the config yourself — or you are authoring a new
+`signoz_dashboard` from an old one you have on file — keep the `import` step (steps
+1-2 and 4 above): the dashboard still needs to be adopted by ID; only the config for
+step 3 is written by hand instead of generated. The attribute mapping is:
+
+| old (v1)                                                               | new (v2)                                                |
+| ---------------------------------------------------------------------- | ------------------------------------------------------- |
+| `title`, `description`                                                 | `spec.display.name`, `spec.display.description`         |
+| `tags` (list of strings)                                               | `tags` (list of `{ key, value }` objects)               |
+| `widgets` (JSON string)                                                | `spec.panels` (map of typed panels, keyed by UUID)      |
+| `layout` (JSON string)                                                 | `spec.layouts` (list of typed grid layouts)             |
+| `variables` (JSON string)                                              | `spec.variables` (list of typed list/text variables)    |
+| `version`                                                              | `schema_version` (set to `"v6"`)                        |
+| `panel_map`, `collapsable_rows_migrated`, `uploaded_grafana`, `source` | removed (folded into `spec.layouts` / no longer needed) |
+
+Because the `spec` tree is large and deeply nested, hand-authoring is error-prone;
+the generated-config path above is strongly recommended.

--- a/templates/guides/v0.0.x-to-v0.1.0.md.tmpl
+++ b/templates/guides/v0.0.x-to-v0.1.0.md.tmpl
@@ -7,51 +7,24 @@ description: |-
 
 # SigNoz Provider v0.0.x to v0.1.0 Upgrade Guide
 
-Version **v0.1.0** completes the SigNoz provider's move to fully typed,
-schema-driven resources generated from the SigNoz OpenAPI spec. Every attribute
-is now a first-class field that Terraform can plan, validate, and diff — there
-are no more opaque `jsonencode(...)` blobs.
+Version **v0.1.0** completes the SigNoz provider's move to fully typed, schema-driven resources generated from the SigNoz OpenAPI spec. Every attribute is now a first-class field that Terraform can plan, validate, and diff — there are no more opaque `jsonencode(...)` blobs.
 
 Two changes are **breaking** and need action before or during the upgrade:
 
-1. [`signoz_alert` has been removed](#signoz_alert-removed) — use `signoz_rule`.
-2. [`signoz_dashboard` moved to a typed v2 schema](#signoz_dashboard-v1-to-v2) —
-   the old JSON-string configuration must be migrated.
+1. [`signoz_alert` has been removed](#signoz_alert-removed) - use `signoz_rule`.
+2. [`signoz_dashboard` moved to a typed v2 schema](#signoz_dashboard-v1-to-v2) - the old JSON-string configuration must be migrated.
 
 If you use neither resource, upgrading to v0.1.0 needs no configuration changes.
 
 ## `signoz_alert` removed
 
-`signoz_alert` — built on the SigNoz v1 rules API, with `condition` and
-`evaluation` carried as opaque `jsonencode(...)` strings — has been removed. Its
-replacement is [`signoz_rule`](../resources/rule): the same alert rules on the
-**v2 rules API** (`/api/v2/rules`, `schema_version = "v2alpha1"`), with every
-field typed and validated at plan time.
-
-The rule data on the server is untouched — the v1 and v2 APIs are two views over
-one rule store — so this is a Terraform resource-*type* change, not a rule
-rewrite. Terraform can generate the typed `signoz_rule` configuration for you
-from the live rule using an `import` block and `-generate-config-out`.
-
-Migrate each rule while still on a v0.0.x provider (where `signoz_alert` still
-exists), then upgrade to v0.1.0. The dedicated [**Migrating from `signoz_alert`
-to `signoz_rule`**](migrate-signoz-alert-to-signoz-rule) guide has the full
-step-by-step workflow and the attribute-by-attribute mapping.
+Migrate each rule while still on a v0.0.x provider (where `signoz_alert` still exists), then upgrade to v0.1.0. The dedicated [**Migrating from `signoz_alert` to `signoz_rule`**](migrate-signoz-alert-to-signoz-rule) guide has the full step-by-step workflow and the attribute-by-attribute mapping.
 
 ## `signoz_dashboard` v1 to v2
 
-v0.1.0 replaces the `signoz_dashboard` resource and data source with a new
-implementation built on the SigNoz dashboards **v2 API** (`/api/v2/dashboards`),
-available in **SigNoz v0.135.0 and newer**. The new schema models a dashboard as
-a fully typed [Perses](https://perses.dev) specification instead of opaque JSON
-strings, so every panel, query, variable, and grid layout is a first-class
-attribute Terraform validates at plan time.
+v0.1.0 replaces the `signoz_dashboard` resource and data source with a new implementation built on the SigNoz dashboards **v2 API** (`/api/v2/dashboards`), available in **SigNoz v0.135.0 and newer**. The new schema models a dashboard as a fully typed [Perses](https://perses.dev) specification instead of opaque JSON strings, so every panel, query, variable, and grid layout is a first-class attribute Terraform validates at plan time.
 
-~> **This is a breaking change.** The resource's entire attribute set changed, so
-existing configurations and state must be migrated. The dashboard data on the
-server is untouched — importing adopts the existing dashboard by ID — so this is
-a Terraform resource *schema* change, not a dashboard rewrite, and Terraform can
-generate the new typed configuration for you.
+~> **This is a breaking change.** The resource's entire attribute set changed, so existing configurations and state must be migrated. Terraform can generate the new typed configuration for you.
 
 ### What changed
 
@@ -73,9 +46,7 @@ resource "signoz_dashboard" "old" {
 }
 ```
 
-The v2 resource replaces those with a typed tree under `spec`, so every panel,
-query, variable, and layout is a first-class attribute that Terraform can plan
-and validate:
+The v2 resource replaces those with a typed tree under `spec`, so every panel, query, variable, and layout is a first-class attribute that Terraform can plan and validate:
 
 ```terraform
 resource "signoz_dashboard" "new" {
@@ -93,14 +64,13 @@ resource "signoz_dashboard" "new" {
     }
 
     variables = [/* typed list/text variables */]
-    panels    = { /* keyed by panel UUID */ }
+    panels    = { /* keyed by panel names */ }
     layouts   = [/* grid layouts referencing panels by $ref */]
   }
 }
 ```
 
-See the [`signoz_dashboard` resource documentation](../resources/dashboard) for a
-complete, working example.
+See the [`signoz_dashboard` resource documentation](../resources/dashboard) for a complete, working example.
 
 ### Before you begin
 
@@ -117,23 +87,16 @@ complete, working example.
 
 ### Recommended: let Terraform generate the typed config
 
-Because the v2 `signoz_dashboard` implements import plus a full typed read (a `GET`
-on the v2 API mapped into the typed model), Terraform can write the v2 HCL for you
-with `-generate-config-out`. This is the easiest and least error-prone path — the
-generated config is schema-correct by construction and matches the live dashboard.
+Because the v2 `signoz_dashboard` implements import plus a full typed read (a `GET` on the v2 API mapped into the typed model), Terraform can write the v2 HCL for you with `-generate-config-out`. This is the easiest and least error-prone path — the generated config is schema-correct by construction and matches the live dashboard.
 
-For each dashboard (`<name>` = the resource label, `<dashboard-id>` = the ID you
-recorded):
+For each dashboard (`<name>` = the resource label, `<dashboard-id>` = the ID you recorded):
 
-1. **Remove the old resource from state.** This is a resource-*schema* change, not
-   an in-place upgrade, so the v1 entry has to leave state first:
-
+1. **Remove the old resource from state.** This is a resource-*schema* change, not an in-place upgrade, so the v1 entry has to leave state first:
    ```sh
    terraform state rm signoz_dashboard.<name>
    ```
 
 2. **Add an `import` block** pointing the resource at the existing dashboard ID:
-
    ```terraform
    # migrate.tf — delete once migration is done
    import {
@@ -150,7 +113,6 @@ recorded):
    ```
 
 4. **Execute the import:**
-
    ```sh
    terraform apply
    ```
@@ -164,34 +126,26 @@ recorded):
      panel/query tree is worth eyeballing.
 
 6. **Confirm no drift:**
-
    ```sh
    terraform plan   # should report: No changes
    ```
 
-Repeat per dashboard until every v1 `signoz_dashboard` block is gone from your
-configuration.
+Repeat per dashboard until every v1 `signoz_dashboard` block is gone from your configuration.
 
--> The generated config is emitted directly from what the v2 API returns, so it is
-always a valid v2 dashboard. If step 6 shows a diff, treat it as real drift (or a
-bug to report) rather than editing blindly.
+-> The generated config is emitted directly from what the v2 API returns, so it is always a valid v2 dashboard. If step 6 shows a diff, treat it as real drift (or a bug to report) rather than editing blindly.
 
 ### Alternative: rewrite the config by hand
 
-If you would rather translate the config yourself — or you are authoring a new
-`signoz_dashboard` from an old one you have on file — keep the `import` step (steps
-1-2 and 4 above): the dashboard still needs to be adopted by ID; only the config for
-step 3 is written by hand instead of generated. The attribute mapping is:
+If you would rather translate the config yourself — or you are authoring a new `signoz_dashboard` from an old one you have on file — keep the `import` step (steps 1-2 and 4 above): the dashboard still needs to be adopted by ID; only the config for step 3 is written by hand instead of generated. The attribute mapping is:
 
 | old (v1)                                                               | new (v2)                                                |
 | ---------------------------------------------------------------------- | ------------------------------------------------------- |
 | `title`, `description`                                                 | `spec.display.name`, `spec.display.description`         |
 | `tags` (list of strings)                                               | `tags` (list of `{ key, value }` objects)               |
-| `widgets` (JSON string)                                                | `spec.panels` (map of typed panels, keyed by UUID)      |
+| `widgets` (JSON string)                                                | `spec.panels` (map of typed panels, keyed by panel name) |
 | `layout` (JSON string)                                                 | `spec.layouts` (list of typed grid layouts)             |
 | `variables` (JSON string)                                              | `spec.variables` (list of typed list/text variables)    |
 | `version`                                                              | `schema_version` (set to `"v6"`)                        |
 | `panel_map`, `collapsable_rows_migrated`, `uploaded_grafana`, `source` | removed (folded into `spec.layouts` / no longer needed) |
 
-Because the `spec` tree is large and deeply nested, hand-authoring is error-prone;
-the generated-config path above is strongly recommended.
+Because the `spec` tree is large and deeply nested, hand-authoring is error-prone; the generated-config path above is strongly recommended.

--- a/templates/guides/v0.0.x-to-v0.1.0.md.tmpl
+++ b/templates/guides/v0.0.x-to-v0.1.0.md.tmpl
@@ -16,7 +16,7 @@ Two changes are **breaking** and need action before or during the upgrade:
 
 1. [`signoz_alert` has been removed](#signoz_alert-removed) — use `signoz_rule`.
 2. [`signoz_dashboard` moved to a typed v2 schema](#signoz_dashboard-v1-to-v2) —
-   the old JSON-string configuration must be rewritten.
+   the old JSON-string configuration must be migrated.
 
 If you use neither resource, upgrading to v0.1.0 needs no configuration changes.
 
@@ -41,11 +41,17 @@ step-by-step workflow and the attribute-by-attribute mapping.
 ## `signoz_dashboard` v1 to v2
 
 v0.1.0 replaces the `signoz_dashboard` resource and data source with a new
-implementation built on the SigNoz dashboards **v2 API** (`/api/v2/dashboards`).
-The new schema models a dashboard as a fully typed [Perses](https://perses.dev)
-specification instead of opaque JSON strings. This is a **breaking change**: the
-resource's entire attribute set changed, so existing configurations and state
-must be migrated.
+implementation built on the SigNoz dashboards **v2 API** (`/api/v2/dashboards`),
+available in **SigNoz v0.135.0 and newer**. The new schema models a dashboard as
+a fully typed [Perses](https://perses.dev) specification instead of opaque JSON
+strings, so every panel, query, variable, and grid layout is a first-class
+attribute Terraform validates at plan time.
+
+~> **This is a breaking change.** The resource's entire attribute set changed, so
+existing configurations and state must be migrated. The dashboard data on the
+server is untouched — importing adopts the existing dashboard by ID — so this is
+a Terraform resource *schema* change, not a dashboard rewrite, and Terraform can
+generate the new typed configuration for you.
 
 ### What changed
 
@@ -96,39 +102,96 @@ resource "signoz_dashboard" "new" {
 See the [`signoz_dashboard` resource documentation](../resources/dashboard) for a
 complete, working example.
 
-#### Attribute mapping
+### Before you begin
 
-| old (v1)                                                     | new (v2)                                                   |
-| ------------------------------------------------------------ | ---------------------------------------------------------- |
-| `title`, `description`                                       | `spec.display.name`, `spec.display.description`            |
-| `tags` (list of strings)                                     | `tags` (list of `{ key, value }` objects)                  |
-| `widgets` (JSON string)                                      | `spec.panels` (map of typed panels, keyed by UUID)         |
-| `layout` (JSON string)                                       | `spec.layouts` (list of typed grid layouts)                |
-| `variables` (JSON string)                                    | `spec.variables` (list of typed list/text variables)       |
-| `version`                                                    | `schema_version`                                           |
-| `panel_map`, `collapsable_rows_migrated`, `uploaded_grafana` | removed (folded into `spec.layouts` / no longer needed)    |
+- **Terraform 1.5 or newer**, for the recommended import-block workflow (`import {}` + `-generate-config-out`).
+- **SigNoz v0.135.0 or newer**, which exposes the dashboards v2 API.
+- The dashboard already exists on the server. Importing adopts it by ID — no dashboard is created, deleted, or interrupted during migration.
+- **Record each dashboard's ID first.** You need it to import, and it leaves state when you remove the old resource:
 
-### Upgrade steps
+  ```sh
+  terraform state show signoz_dashboard.<name>   # copy the `id` value
+  ```
 
-Because the schema changed completely, there is no in-place attribute rename — the
-configuration has to be rewritten:
+-> SigNoz is migrating legacy v1 dashboards to the v2 schema on the server side (see [SigNoz/signoz#12177](https://github.com/SigNoz/signoz/issues/12177)). Once a dashboard is available through the v2 API, the workflow below generates its typed config directly.
 
-1. **Remove the old resource from state** so Terraform stops tracking the v1 shape:
+### Recommended: let Terraform generate the typed config
+
+Because the v2 `signoz_dashboard` implements import plus a full typed read (a `GET`
+on the v2 API mapped into the typed model), Terraform can write the v2 HCL for you
+with `-generate-config-out`. This is the easiest and least error-prone path — the
+generated config is schema-correct by construction and matches the live dashboard.
+
+For each dashboard (`<name>` = the resource label, `<dashboard-id>` = the ID you
+recorded):
+
+1. **Remove the old resource from state.** This is a resource-*schema* change, not
+   an in-place upgrade, so the v1 entry has to leave state first:
 
    ```sh
    terraform state rm signoz_dashboard.<name>
    ```
 
-2. **Rewrite the configuration** using the v2 schema (see the resource documentation
-   and example).
+2. **Add an `import` block** pointing the resource at the existing dashboard ID:
 
-3. **Import the existing dashboard** back into state under the new schema:
-
-   ```sh
-   terraform import signoz_dashboard.<name> <dashboard-id>
+   ```terraform
+   # migrate.tf — delete once migration is done
+   import {
+     to = signoz_dashboard.<name>
+     id = "<dashboard-id>"
+   }
    ```
 
-4. Run `terraform plan` and reconcile any remaining differences.
+3. **Generate the typed config.** Terraform reads the dashboard through the v2 API
+   and writes the full typed `signoz_dashboard` block:
 
-Alternatively, if you manage dashboards as code and can recreate them, delete the old
-dashboards and apply the new configuration from scratch.
+   ```sh
+   terraform plan -generate-config-out=generated.tf
+   ```
+
+4. **Execute the import:**
+
+   ```sh
+   terraform apply
+   ```
+
+5. **Clean up.** Move the block from `generated.tf` into your real configuration,
+   then:
+   - delete the old `signoz_dashboard` block from your config,
+   - delete `migrate.tf` and `generated.tf`,
+   - trim the generated block if you like. `-generate-config-out` emits every
+     optional and computed attribute, so it is verbose; the deeply nested
+     panel/query tree is worth eyeballing.
+
+6. **Confirm no drift:**
+
+   ```sh
+   terraform plan   # should report: No changes
+   ```
+
+Repeat per dashboard until every v1 `signoz_dashboard` block is gone from your
+configuration.
+
+-> The generated config is emitted directly from what the v2 API returns, so it is
+always a valid v2 dashboard. If step 6 shows a diff, treat it as real drift (or a
+bug to report) rather than editing blindly.
+
+### Alternative: rewrite the config by hand
+
+If you would rather translate the config yourself — or you are authoring a new
+`signoz_dashboard` from an old one you have on file — keep the `import` step (steps
+1-2 and 4 above): the dashboard still needs to be adopted by ID; only the config for
+step 3 is written by hand instead of generated. The attribute mapping is:
+
+| old (v1)                                                               | new (v2)                                                |
+| ---------------------------------------------------------------------- | ------------------------------------------------------- |
+| `title`, `description`                                                 | `spec.display.name`, `spec.display.description`         |
+| `tags` (list of strings)                                               | `tags` (list of `{ key, value }` objects)               |
+| `widgets` (JSON string)                                                | `spec.panels` (map of typed panels, keyed by UUID)      |
+| `layout` (JSON string)                                                 | `spec.layouts` (list of typed grid layouts)             |
+| `variables` (JSON string)                                              | `spec.variables` (list of typed list/text variables)    |
+| `version`                                                              | `schema_version` (set to `"v6"`)                        |
+| `panel_map`, `collapsable_rows_migrated`, `uploaded_grafana`, `source` | removed (folded into `spec.layouts` / no longer needed) |
+
+Because the `spec` tree is large and deeply nested, hand-authoring is error-prone;
+the generated-config path above is strongly recommended.


### PR DESCRIPTION
#### Chores

- Rework the `signoz_dashboard` v1→v2 section of the v0.0.x→v0.1.0 upgrade guide to mirror the `signoz_alert` migration guide: recommend the `import {}` + `terraform plan -generate-config-out` workflow (the v2 resource supports import and a full typed read), add a **Before you begin** section, and keep the hand-rewrite as an alternative.
- Note the **SigNoz v0.135.0** requirement for the dashboards v2 API and add the missing `source` attribute to the removed list.

Refs #122.