### PR TITLE
chore(tests): apply the py-comments rule

### DIFF
--- a/.claude/rules/py-comments.md
+++ b/.claude/rules/py-comments.md
@@ -8,5 +8,5 @@ paths:
 The bar is the [`comments`](comments.md) rule: nothing where the code is self-explanatory.
 
 - **No file-level docstring.** The filename says what the module is for — `tool_bin.py` gets the tool binary. A module docstring restating that is noise, and a paragraph of design prose at the top of a file goes stale where nobody is looking. A constraint belongs next to the code it constrains, not in a preamble.
-- **Docstrings**: one line, and only when it says something the name and signature don't. Drop it otherwise.
+- **Docstrings**: only when they say something the name and signature don't — drop them otherwise. Keep them short. A contract that genuinely needs a few lines (interacting flags, retry semantics, an edge case) is fine; a narrative is not.
 - **No song and dance.** Comment the constraint or the edge case. Not the narrative, not the rationale, not what the next line does.

--- a/tests/fixtures/channels.py
+++ b/tests/fixtures/channels.py
@@ -1,9 +1,3 @@
-"""Seed the notification channels the example alerts and route policies reference.
-
-The examples route to channels named "slack" and "pagerduty". SigNoz validates
-that referenced channels exist, so they must be created before the CRUD cycle.
-"""
-
 import pytest
 import requests
 
@@ -19,7 +13,6 @@ _TIMEOUT = 10
 
 
 def ensure_webhook_channel(signoz: SigNoz, name: str) -> None:
-    """Create a webhook notification channel by name if it does not already exist."""
     headers = {"SIGNOZ-API-KEY": signoz.access_token}
 
     listing = requests.get(f"{signoz.endpoint}/api/v1/channels", headers=headers, timeout=_TIMEOUT)
@@ -41,7 +34,7 @@ def ensure_webhook_channel(signoz: SigNoz, name: str) -> None:
 
 @pytest.fixture(scope="session")
 def webhook_channels(signoz: SigNoz) -> tuple[str, ...]:
-    """Ensure the 'slack' and 'pagerduty' webhook channels exist for the examples."""
+    """Seed the channels the configs reference; SigNoz rejects a rule pointing at one that does not exist."""
     for name in WEBHOOK_CHANNELS:
         ensure_webhook_channel(signoz, name)
 

--- a/tests/fixtures/foundry.py
+++ b/tests/fixtures/foundry.py
@@ -41,10 +41,7 @@ def compose_file() -> Path | None:
 
 
 def cast(foundryctl: str) -> str:
-    """Bring up SigNoz and return its endpoint.
-
-    No-op when SIGNOZ_ENDPOINT is set (an existing instance is used as-is).
-    """
+    """Bring up SigNoz and return its endpoint; a no-op when SIGNOZ_ENDPOINT already points at one."""
     external = os.environ.get("SIGNOZ_ENDPOINT")
     if external:
         logger.info("using existing SigNoz at %s (SIGNOZ_ENDPOINT set)", external)

--- a/tests/fixtures/signoz.py
+++ b/tests/fixtures/signoz.py
@@ -1,11 +1,3 @@
-"""Provide a reachable, authenticated SigNoz instance to the integration tests.
-
-The casting provisions a root user on first boot. We log in as that root user,
-mint a service-account API key (the token the Terraform provider authenticates
-with), and hand back a SigNoz handle. The whole environment is created/torn down
-through the --reuse / --teardown machinery in fixtures.reuse.
-"""
-
 import time
 from dataclasses import dataclass
 
@@ -29,8 +21,6 @@ SERVICE_ACCOUNT_ROLE = "signoz-admin"
 
 @dataclass(frozen=True)
 class SigNoz:
-    """A reachable, authenticated SigNoz instance."""
-
     endpoint: str
     access_token: str
 

--- a/tests/integration/tests/test_examples.py
+++ b/tests/integration/tests/test_examples.py
@@ -22,12 +22,9 @@ SKIPPED = {
 def test_resource_file_crud(tf_file: Path, workspace: Callable[[Path], Path], tool_config: Path, signoz: SigNoz, tool_bin: str, webhook_channels: tuple[str, ...]):
     tool = Tool(workspace(tf_file), tool_config, signoz, tool_bin)
 
-    # Create.
     tool.apply()
 
     try:
-        # Read: applying again must be a no-op — no drift.
         assert tool.plan_exit_code() == 0, "drift detected after apply"
     finally:
-        # Delete.
         tool.destroy()

--- a/tests/integration/tests/test_testdata.py
+++ b/tests/integration/tests/test_testdata.py
@@ -1,24 +1,3 @@
-"""End-to-end lifecycle tests for every scenario under testdata/.
-
-Each numbered directory under testdata/resources/signoz_<name>/ is one scenario:
-a single base config plus, optionally, ordered JSON-patch edits.
-
-    signoz_rule/00/
-      01-<name>.tf            # base config (HCL or Terraform JSON)
-
-    signoz_rule/01/
-      01-<name>.tf.json       # base config (Terraform JSON syntax)
-      02-jsonpatch.json       # RFC 6902 patch applied on top of the base
-      03-jsonpatch.json       # RFC 6902 patch applied on top of the previous state
-
-For each scenario the runner creates the base (plan shows a create, apply,
-re-plan is clean), applies each jsonpatch in ascending order — re-plan must show
-changes, apply, re-plan must be clean — and finally destroys. A scenario with no
-patches is just create -> no-drift -> destroy; its base may be plain HCL (.tf).
-A JSON patch needs a JSON target, so a scenario with patches needs a .tf.json
-base (Terraform reads .tf.json natively).
-"""
-
 import json
 from pathlib import Path
 
@@ -58,12 +37,10 @@ def test_scenario_lifecycle(scenario: Path, tmp_path: Path, tool_config: Path, s
         config.write_text(base.read_text())
 
     try:
-        # Create: the first plan is the create, apply, re-plan must be clean.
         assert tool.plan_exit_code() == 2, "expected a create on the first plan"
         tool.apply()
         assert tool.plan_exit_code() == 0, "drift after initial apply"
 
-        # Each patch is one edit: re-plan shows changes, apply, re-plan clean.
         for patch in patches:
             body = jsonpatch.apply_patch(body, json.loads(patch.read_text()))
             named[rname] = body


### PR DESCRIPTION
#### Chores

- Drops the module-level docstrings from the Python suite. The 19-line one in `test_testdata.py` restated the "Test data" section of [`tests/README.md`](tests/README.md), which stays the single source for the scenario layout.
- Drops docstrings and comments that restate the code they sit on — `# Create.` above `tool.apply()`, `ensure_webhook_channel`'s "create it if it does not already exist", the `SigNoz` dataclass summary.
- Keeps the docstrings that carry a constraint, and folds the channels precondition (SigNoz rejects a rule pointing at a channel that does not exist) into the fixture that enforces it.
- Relaxes `py-comments` from "one line" to "keep them short". The rule is meant to mirror `go-comments`, which caps prose rather than lines — a few lines for a real contract, like how `--reuse` and `--teardown` interact in `reuse.wrap`, is worth keeping.